### PR TITLE
Make sure text-properties are removed from contents

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -144,9 +144,9 @@ string or a list."
 This kills any ycmd server already running (under ycmd.el's
 control.) The newly started server will have a new HMAC secret."
   (interactive)
-  
+
   (ycmd-close)
-  
+
   (let ((hmac-secret (ycmd--generate-hmac-secret)))
     (ycmd--start-server hmac-secret)
     (setq ycmd--hmac-secret hmac-secret))
@@ -158,11 +158,11 @@ control.) The newly started server will have a new HMAC secret."
 
 This does nothing if no server is running."
   (interactive)
-  
+
   (unwind-protect
       (when (ycmd-running?)
 	(delete-process ycmd--server-process)))
-  
+
   (ycmd--kill-notification-timer))
 
 (defun ycmd-running? ()
@@ -337,7 +337,7 @@ the name of the newly created file."
   (let ((proc-buff (get-buffer-create "*ycmd-server*")))
     (with-current-buffer proc-buff
       (erase-buffer)
-      
+
       (let* ((options-file (ycmd--create-options-file hmac-secret))
              (server-command (if (listp ycmd-server-command)
                                  ycmd-server-command
@@ -372,7 +372,7 @@ nil, this uses the current buffer.
     (let* ((column-num (+ 1 (save-excursion (goto-char (point)) (current-column))))
            (line-num (line-number-at-pos (point)))
            (full-path (buffer-file-name))
-           (file-contents (buffer-string))
+           (file-contents (buffer-substring-no-properties (point-min) (point-max)))
            (file-types (ycmd--major-mode-to-file-types major-mode)))
       `(("file_data" .
          ((,full-path . (("contents" . ,file-contents)


### PR DESCRIPTION
`buffer-string' function will get fontified information.

Example from my debug information (which contains fontified information because of using `buffer-string'):

```
(("file_data"
  ("/Users/tongmuchenxuan/playground/test2.cpp"
   ("contents" .
    #("#include <vector>\n\nusing namespace std;\n\nint main(int argc, char *argv[]) {\n    vector<int> v;\n    v.\n}\n" 0 1
      (fontified t face font-lock-preprocessor-face c-is-sws t c-in-sws t category c-cpp-delimiter)
      1 8
      (fontified t face font-lock-preprocessor-face c-in-sws t)
      8 9
      (fontified t c-in-sws t)
      9 17
      (fontified t face font-lock-string-face c-in-sws t)
      17 18
      (fontified t c-in-sws t category c-cpp-delimiter)
      18 19
      (fontified t c-is-sws t)
      19 20
      (fontified t c-is-sws t face font-lock-keyword-face)
      20 24
      (fontified t face font-lock-keyword-face)
      24 25
      (fontified t)
      25 34
      (fontified t face font-lock-keyword-face)
      34 35
      (fontified t)
      35 37
      (fontified t face font-lock-constant-face)
      37 38
      (fontified t c-type c-decl-id-start face font-lock-constant-face)
      38 40
      (fontified t)
      40 41
      (fontified t)
      41 43
      (fontified t face font-lock-type-face)
      43 44
      (fontified t c-type c-decl-id-start face font-lock-type-face)
      44 45
      (fontified t)
      45 49
      (fontified t face font-lock-function-name-face)
      49 50
      (fontified t c-type c-decl-arg-start)
      50 53
      (fontified t face font-lock-type-face)
      53 54
      (fontified t)
      54 58
      (fontified t face font-lock-variable-name-face)
      58 59
      (fontified t c-type c-decl-arg-start)
      59 60
      (fontified t)
      60 64
      (fontified t face font-lock-type-face)
      64 66
      (fontified t)
      66 70
      (fontified t face font-lock-variable-name-face)
      70 76
      (fontified t)
      76 80
      (fontified t)
      80 86
      (fontified t face font-lock-type-face)
      86 87
      (category c-<-as-paren-syntax fontified t)
      87 90
      (fontified t face font-lock-type-face)
      90 91
      (category c->-as-paren-syntax fontified t c-type c-decl-id-start)
      91 92
      (fontified t)
      92 93
      (fontified t face font-lock-variable-name-face)
      93 95
      (fontified t)
      95 101
      (fontified t)
      101 102
      (fontified t)
      102 103
      (fontified t)
      103 104
      (fontified t)))
   ("filetypes" "cpp")))
 ("filepath" . "/Users/tongmuchenxuan/playground/test2.cpp")
 ("line_num" . 7)
 ("column_num" . 7))

HTTP RESPONSE CONTENT

nil
```
