### PR TITLE
Implement ycmd-minor-mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Then `require` the emacs-ycmd code in your emacs config:
 
 ```
 (require 'ycmd)
+(add-hook 'c++-mode-hook 'ycmd-mode)
+(add-hook 'python-mode-hook 'ycmd-mode)
 ```
 
 Use the variable `ycmd-server-command` to specify how to run the server. It will typically be something like:


### PR DESCRIPTION
Implement a minor-mode for ycmd. The mode adds hooks in order to have different triggers for a reparse. With the `ycmd-set-needs-parse` list the user is able to control when the buffer should be marked for reparsing. For now `save` and `new-line` or manual reparse is supported, but might be extended for other methods like an idle-timer. 
