### PR TITLE
Using the suggested goto-char from the description of the function end-of-buffer

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -655,7 +655,7 @@ nil, this uses the current buffer.
     (let ((buffer (get-buffer-create "*ycmd-content-log*")))
       (with-current-buffer buffer
         (save-excursion
-          (end-of-buffer)
+          (goto-char (point-max))
           (insert (format "\n%s\n\n" header))
           (insert (pp-to-string content)))))))
 


### PR DESCRIPTION
This also avoid interfering with the user when the content logger is manipulating its content buffer in the background.

Example:
`(setq ycmd--log-enabled t)`
and idle in a buffer with ycmd-minor mode enabled and a message will appear with "Mark set" and sometimes (havn't figured the exact conditions for reproducing this behaviour) it will move the "view" of the current buffer so the cursor location is placed 3 lines from the bottom of the buffer view (without actually changing the cursor's position)...
Also the content in the log will be shown if you idle after having typed `M-x` (I don't recall what that window/buffer is called) - this is really annoying when you are invoking functions manually or switching buffers while some content is being logged.

`M-x RET describe-function RET end-of-buffer` suggests that `(goto-char (point-max))` should be used in Lisp programs, because it's faster - but it also solves the issue I experienced, where `end-of-buffer` interferes with the user.
