### PR TITLE
It's nolonger necessary to inform company of common c++ completion points

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,22 +81,3 @@ that:
 ```
 
 Afer this you can use your standard `company-mode` keybindings to do completion.
-
-Enabling automatic completion after `->` and `::`
--------------------------------------------------
-
-By default `company-mode` will not start automatic completion after
-you type `:` or `>`. To enable this, you need to put
-`c-electric-colon` and `c-electric-lt-gt` into the list
-`company-begin-commands`. So if you want to start automatic completion
-after you type `->` or `::` - which is probably what you want for C
-and C++ - then update that list.
-
-For convenience, the functions
-`company-ycmd-enable-comprehensive-automatic-completion` will do this
-for you.
-
-*These symbols will probably be included in the default
-`copmany-begin-commands` at some point in the future. If you know they
-have been added and you see that I haven't updated this note, please
-let me know!*

--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -180,20 +180,6 @@ of information added as text-properties.
     (sorted          't)
     (post-completion (company-ycmd--post-completion arg))))
 
-(defun company-ycmd-enable-comprehensive-automatic-completion ()
-  "This updates company-begin-commands so that automatic
-completion will occur after typing :: and ->. 
-
-By default company-mode will not start automatic completion
-after : and > characters, so you need to call this if you want
-full automatic completion for C/C++."
-  (interactive)
-  (mapcar
-   (lambda (x)
-     (unless (memq x company-begin-commands)
-       (push x company-begin-commands)))
-   '(c-electric-colon c-electric-lt-gt)))
-
 ;;;###autoload
 (defun company-ycmd-setup ()
   "Add company-ycmd to the front of company-backends"


### PR DESCRIPTION
By looking at the current source code for company, it's now the default to also perform completions after `::` and `->`.
