### PR TITLE
contrib/ami-ycmd-next-error.el: connects ycmd with M-x next-error

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,4 +92,5 @@ Afer this you can use your standard `company-mode` keybindings to do completion.
 ----------
 emacs-ycmd reports found errors through emacs buttons; to integrate those with
 ```next-error``` prepend something like
-```(load-file "contrib/ami-ycmd-next-error.el")``` before require'ing ycmd.
+```(require 'ycmd-next-error)``` before require'ing ycmd (after adding the
+```contrib``` directory to your ```load-path```).

--- a/contrib/ycmd-next-error.el
+++ b/contrib/ycmd-next-error.el
@@ -1,24 +1,29 @@
+(require 'pulse)
+
 ;;(setq next-error-hook nil)
 (add-hook 'next-error-hook
-          '(lambda () (interactive)
-             (if (ami-at-ycmd-button (point)) (push-button)
+          '(lambda ()
+             (if (ycmd-next-error-at-ycmd-button (point)) (push-button)
                (let ((compilation-buffer (get-buffer "*compilation*")))
                  (when compilation-buffer
                    (save-excursion
                      (set-buffer "*compilation*")
                      (move-beginning-of-line nil)
                      (pulse-line-hook-function)))))))
+
 (eval-after-load "ycmd"
   '(add-hook 'ycmd-mode-hook
-             '(lambda () (interactive)
-                (setq next-error-function 'ami-ycmd-next-error))))
-(defun ami-at-ycmd-button (cur)
+             '(lambda ()
+                (setq next-error-function 'ycmd-next-error-goto-next-error))))
+
+(defun ycmd-next-error-at-ycmd-button (cur)
   "Returns whether CUR is at a ycmd button."
   (let* ((button (button-at cur))
          (type (and button (button-type button))))
     (or (eq type 'ycmd--error-button)
         (eq type 'ycmd--warning-button))))
-(defun ami-ycmd-next-error (&optional count reset)
+
+(defun ycmd-next-error-goto-next-error (&optional count reset)
   "Go to next YCM-detected error in the current buffer, or stay put if none"
   (interactive)
   (when (null count) (setq count 0))
@@ -29,10 +34,12 @@
     (save-excursion
       (when (and
              (setq cur (funcall (symbol-function move-fn) cur))
-             (ami-at-ycmd-button cur))
+             (ycmd-next-error-at-ycmd-button cur))
         (setq target cur)))
     (if (not (and count target))
         (message "Reached last error")
       (goto-char target)
       (when (not (eq next-count 0))
-        (ami-ycmd-next-error next-count nil)))))
+        (ycmd-next-error-goto-next-error next-count nil)))))
+
+(provide 'ycmd-next-error)


### PR DESCRIPTION
Added my hack to contrib/ per suggestion in issue #74.
