### PR TITLE
Set a 'generic' filetype for not supported filetypes

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -759,7 +759,8 @@ nil, this uses the current buffer.
            (line-num (line-number-at-pos (point)))
            (full-path (buffer-file-name))
            (file-contents (buffer-substring-no-properties (point-min) (point-max)))
-           (file-types (ycmd--major-mode-to-file-types major-mode)))
+           (file-types (or (ycmd--major-mode-to-file-types major-mode)
+                           '("generic"))))
       `(("file_data" .
          ((,full-path . (("contents" . ,file-contents)
                          ("filetypes" . ,file-types)))))


### PR DESCRIPTION
Since `ycmd-mode` is used to check whether completion should work, we have to add some filetype in the request. The filetype cannot be nil or an empty string in the request. 
