### PR TITLE
Return end position of candidate in match function

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -154,7 +154,7 @@ of information added as text-properties.
   (cons :async 'company-ycmd--get-candidates))
 
 (defun company-ycmd--match (prefix)
-  (point))
+  (length prefix))
 
 (defun company-ycmd--post-completion (arg)
   (let ((params (company-ycmd--params arg)))


### PR DESCRIPTION
The function should return the position of the end of the candidate that
matches prefix. This fixes font-locking in company popup.
