### PR TITLE
Add a defustom for enable/disable fuzzy matching

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -83,6 +83,14 @@
   :type 'boolean
   :group 'company-ycmd)
 
+(defcustom company-ycmd-enable-fuzzy-matching t
+  "When non-nil, use fuzzy matching for completion candidates.
+
+Setting this to non-nil disables the `company-mode' internal
+cache feature, in order to be able to use ycmd's fuzzy matching."
+  :type 'boolean
+  :group 'company-ycmd)
+
 (defun company-ycmd--construct-candidate (src)
   "Converts a ycmd completion structure to a candidate string.
 
@@ -172,8 +180,9 @@ of information added as text-properties.
     (candidates      (company-ycmd--candidates arg))
     (meta            (company-ycmd--meta arg))
     (annotation      (company-ycmd--annotation arg))
-    (match           (company-ycmd--match arg))
-    (no-cache        't) ; Don't cache. It interferes with fuzzy matching.
+    (match           (when company-ycmd-enable-fuzzy-matching
+                       (company-ycmd--match arg)))
+    (no-cache        company-ycmd-enable-fuzzy-matching)
     (sorted          't)
     (post-completion (company-ycmd--post-completion arg))))
 


### PR DESCRIPTION
using company's caching feature improves performance slightly because it does not send a completion request on every keystroke. I think it is useful to be able to configure the behaviour.
