### PR TITLE
Remove idle-change from default parse conditions

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -211,7 +211,7 @@ re-parsing the contents."
   :group 'ycmd
   :type '(number))
 
-(defcustom ycmd-parse-conditions '(save new-line idle-change mode-enabled)
+(defcustom ycmd-parse-conditions '(save new-line mode-enabled)
   "When ycmd should reparse the buffer.
 
 The variable is a list of events that may trigger parsing the


### PR DESCRIPTION
I think it is sufficient to send file parse request when opening or saving the buffer and on entering a new line by default. Any opinions @abingham ?
