### PR TITLE
show server buffer on timeout

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -760,6 +760,7 @@ the name of the newly created file."
              (t
               (incf cont)
               (when (< 3000 cont) ; timeout after 3 seconds
+                (set-window-buffer nil proc-buff)
                 (error "Server timeout."))))))))))
 
 (defun ycmd--standard-content (&optional buffer)


### PR DESCRIPTION
I had '~' in the path for `ycmd-server-command` and got a "timeout" immediately which I didn't notice because some other message came after the error.

(I don't know how often these timeouts happens in practice; if timeouts are expected once in a while so that this becomes annoying, then maybe start-server should only show the buffer if the process _exited_ within 3s.)
