### PR TITLE
Report parsing status on mode-line

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -231,14 +231,14 @@ of information added as text-properties.
 
 (defun company-ycmd--prefix ()
   "Prefix-command handler for the company backend."
-  (when ycmd--notification-in-progress
+  (when (ycmd-parsing-in-progress-p)
     (message "Ycmd completion unavailable while parsing is in progress."))
   
   (and ycmd-mode
        buffer-file-name
        (ycmd-running?)
        (not (company-in-string-or-comment))
-       (or (and (not ycmd--notification-in-progress)
+       (or (and (not (ycmd-parsing-in-progress-p))
                 (let ((triggers-re "\\.\\|->\\|::"))
                   (if (looking-back triggers-re)
                       (company-grab-symbol-cons triggers-re 2)

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -92,7 +92,7 @@ Return the buffer.
       (ycmd-open)
       (ycmd-mode t)
       (funcall mode)
-      (while ycmd--notification-in-progress (sit-for 0.1)))
+      (while (ycmd-parsing-in-progress-p) (sit-for 0.1)))
     buff))
 
 (ert-deftest ycmd-test-completions ()


### PR DESCRIPTION
This is the basic implementation to show the status on the mode-line. It only supports showing whether parsing is in progress.

It would be nice to indicate also errors, i.e. no extra conf file or no compile flags errors...
