### PR TITLE
Constrained semantic support

### DIFF
--- a/flycheck-ycmd.el
+++ b/flycheck-ycmd.el
@@ -93,8 +93,7 @@ display."
 
 (defun flycheck-ycmd--in-supported-mode ()
   "Determines if buffer is in `ycmd-mode` and another mode supported by ycmd."
-  (and ycmd-mode
-       (-contains? (mapcar 'car ycmd-file-type-map) major-mode)))
+  (and ycmd-mode (ycmd-semantic-file-types major-mode)))
 
 (defun flycheck-ycmd-setup ()
   "Convenience function to setup the ycmd flycheck checker.

--- a/ycmd.el
+++ b/ycmd.el
@@ -260,6 +260,24 @@ use `ycmd-parse-buffer'."
   :group 'ycmd
   :type '(alist :key-type symbol :value-type (repeat string)))
 
+(defconst ycmd-semantic-completion-file-types
+  '("c"
+    "cpp"
+    "objc"
+    "objcpp"
+    "cs"
+    "python")
+  "A list of ycmd file type strings which support semantic completion.")
+
+(defun ycmd-semantic-file-types (mode)
+  "Find the ycmd file types for MODE which support semantic completion.
+
+Returns a possibly empty list of ycmd file type strings.  If this
+is empty, then ycmd doesn't support semantic completion (or
+diagnostics) for MODE."
+  (let ((file-types (assoc-default mode ycmd-file-type-map)))
+    (-intersection file-types ycmd-semantic-completion-file-types)))
+
 (defun ycmd-open ()
   "Start a new ycmd server.
 


### PR DESCRIPTION
We now maintain an explicit list of ycmd file types which support semantic completion. These types are the only ones for which we can hope to get reports on errors, warnings, etc. As such, we limit flycheck to, at most, modes which map to these types.

In other words, we no longer try to use flycheck-ycmd for files for which it will never work.