### PR TITLE
;;;###autoload flycheck-setup

### DIFF
--- a/flycheck-ycmd.el
+++ b/flycheck-ycmd.el
@@ -95,6 +95,7 @@ display."
   "Determines if buffer is in `ycmd-mode` and another mode supported by ycmd."
   (and ycmd-mode (ycmd-diagnostic-file-types major-mode)))
 
+;;;###autoload
 (defun flycheck-ycmd-setup ()
   "Convenience function to setup the ycmd flycheck checker.
 


### PR DESCRIPTION
for people who install with package.el and only want it loaded when
needed, e.g.

    (eval-after-load "flycheck-ycmd-autoloads"
      '(add-hook 'ycmd-mode-hook 'flycheck-ycmd-setup))