### PR TITLE
Fix condition in ycmd--on-change function

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -920,7 +920,7 @@ or is nil."
 (defun ycmd--on-change (beg end _len)
   "Function to run when a buffer change between BEG and END."
   (save-match-data
-    (when (and ycmd-mode (not (eq beg end)))
+    (when ycmd-mode
       (ycmd--kill-notification-timer)
       (if (string-match-p "\n" (buffer-substring beg end))
           (ycmd--conditional-parse 'new-line)


### PR DESCRIPTION
Remove the check whether beg and end are not equal, because when
deleting a character beg and end are equal and therefore condition
should be true.