### PR TITLE
Fix ycmd--locate-default-tags-file for case insensitive file-systems.

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -231,6 +231,11 @@ use `ycmd-parse-buffer'."
               (const :tag "After a `ycmd-mode' was enabled." mode-enabled))
   :safe #'listp)
 
+(defcustom ycmd-default-tags-file-name "tags"
+  "The default tags file name."
+  :group 'ycmd
+  :type 'string)
+
 (defcustom ycmd-force-semantic-completion nil
   "Whether to use always semantic completion."
   :group 'ycmd
@@ -248,7 +253,7 @@ nil
 
 `auto'
     Look up directory hierarchy for first found tags file with
-    default names 'tags' or 'TAGS'.
+    `ycmd-default-tags-file-name'.
 
 string
     A tags file name.
@@ -388,16 +393,14 @@ Returns the new value of `ycmd-force-semantic-completion`.
   (and (listp obj) (-all? #'stringp obj)))
 
 (defun ycmd--locate-default-tags-file (buffer)
-  "Look up directory hierarchy for first found tags file for BUFFER."
+  "Look up directory hierarchy for first found default tags file for BUFFER."
   (let* ((directory (locate-dominating-file
                      (file-name-directory (buffer-file-name buffer))
                      (lambda (path)
-                       (directory-files path t "^\\(TAGS\\|tags\\)"))))
+                       (directory-files
+                        path t (regexp-quote ycmd-default-tags-file-name)))))
          (tags-file (and directory
-                         (or (and (file-exists-p (expand-file-name "TAGS" directory))
-                                  (expand-file-name "TAGS" directory))
-                             (and (file-exists-p (expand-file-name "tags" directory))
-                                  (expand-file-name "tags" directory))))))
+                         (expand-file-name ycmd-default-tags-file-name directory))))
     tags-file))
 
 (defun ycmd--get-tag-files (buffer)


### PR DESCRIPTION
On case insensitive file systems if we look for both small letters and
capitalized version of the same tags file name, we get incorrect result
because 'file-exists-p' is in that case also case insensitive. Introduce
a defcustom for default tags name.

I noticed this issue today when I was working on a Mac, which could not distinct `TAGS` and `tags`. On Linux the other approach worked well.

Anyways, I think this solution is better because it simplifies the automatic tags file lookup.

Sidenote: `ctags` default tags file name is `tags` and with option `-e` (Emacs) is `TAGS`.