### PR TITLE
Remove trailing parentheses from insert string

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -148,9 +148,10 @@ extracts the 'insertion_text', attaches other properties to that
 string as text-properties, and returns the string."
   (let* ((prefix-start-col (- (+ 1 (ycmd--column-in-bytes)) (length prefix)))
          (prefix-size (- start-col prefix-start-col))
-	 (candidate (concat (substring-no-properties prefix 0 prefix-size)
-			    (substring-no-properties
-			     (assoc-default 'insertion_text src)))))
+         (insertion-text (assoc-default 'insertion_text src))
+         (candidate (concat (substring-no-properties prefix 0 prefix-size)
+                            (substring-no-properties
+                             (s-chop-suffix "()" insertion-text)))))
     (put-text-property 0 1 'meta meta candidate)
     (when (and meta
                (string-match


### PR DESCRIPTION
ycmd now adds parentheses for candidates with no function arguments to
the insert string. See commit https://github.com/Valloric/ycmd/commit/443b99f69d4932b8feab43f6841a1480d3e7edc7

This adds a second pair of parentheses to the
candidate test in the company popup. The first is the one from the
insertion_text adn the other is from the annotation.