### PR TITLE
Company ycmd refactoring

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -95,7 +95,7 @@ feature."
   :group 'company-ycmd)
 
 (defconst company-ycmd--extended-features-modes
-  '(c++-mode c-mode)
+  '(c++-mode c-mode python-mode)
   "Major modes which have extended features in `company-ycmd'.")
 
 (defun company-ycmd--extended-features-p ()
@@ -166,6 +166,16 @@ functions."
                             'meta meta 'kind kind 'doc doc 'params cand)
                 candidates))))))
 
+(defun company-ycmd--construct-candidate-python (candidate prefix start-col)
+  "Construct completion string from a CANDIDATE for python file-types.
+
+PREFIX and START-COL are used to generate insertion text."
+  (company-ycmd--with-destructured-candidate candidate prefix start-col
+    (let ((params (and detailed-info
+                       (car (s-split-up-to "\n" detailed-info 1)))))
+      (propertize item 'meta detailed-info
+                  'kind extra-menu-info 'params params))))
+
 (defun company-ycmd--construct-candidate-generic (candidate prefix start-col)
   "Generic function to construct completion string from a CANDIDATE.
 
@@ -202,6 +212,7 @@ candidates list."
   "Return function to construct candidate(s) for current `major-mode'."
   (pcase (ycmd-major-mode-to-file-types major-mode)
     (`("cpp") 'company-ycmd--construct-candidate-cpp)
+    (`("python") 'company-ycmd--construct-candidate-python)
     (_ 'company-ycmd--construct-candidate-generic)))
 
 (defun company-ycmd--get-candidates (cb prefix)

--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -165,13 +165,13 @@ string as text-properties, and returns the string."
 (defun company-ycmd--get-candidates (cb prefix)
   "Call CB with completion candidates for PREFIX at the current point."
   (deferred:$
-    
+
     (deferred:try
       (deferred:$
         (if (ycmd-running?)
             (ycmd-get-completions (current-buffer) (point))))
       :catch (lambda (err) nil))
-    
+
     (deferred:nextc it
       (lambda (c)
         (if (assoc-default 'exception c)
@@ -179,11 +179,11 @@ string as text-properties, and returns the string."
             (let ((msg (assoc-default 'message c nil "unknown error")))
               (message "Exception while fetching candidates: %s" msg)
               '())
-          
+
           (funcall
            cb
            (company-ycmd--construct-candidates
-	    (assoc-default 'completion_start_column c)
+            (assoc-default 'completion_start_column c)
             (assoc-default 'completions c)
 	    prefix)))))))
 
@@ -328,3 +328,7 @@ string as text-properties, and returns the string."
 (provide 'company-ycmd)
 
 ;;; company-ycmd.el ends here
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:

--- a/ycmd.el
+++ b/ycmd.el
@@ -314,7 +314,7 @@ is empty, then ycmd doesn't support semantic completion (or
 diagnostics) for MODE."
   (-intersection
    ycmd--diagnostic-file-types
-   (ycmd--major-mode-to-file-types mode)))
+   (ycmd-major-mode-to-file-types mode)))
 
 (defun ycmd-open ()
   "Start a new ycmd server.
@@ -581,6 +581,8 @@ When clicked, this will popup MESSAGE."
     (point)))
 
 (defmacro ycmd--with-destructured-parse-result (result body)
+  "Destructure parse RESULT and evaluate BODY."
+  (declare (indent 1) (debug t))
   `(let* ((location_extent  (assoc-default 'location_extent ,result))
           (le_end           (assoc-default 'end location_extent))
           (end-line-num     (assoc-default 'line_num le_end))
@@ -759,8 +761,8 @@ This is primarily a debug/developer tool."
 (defconst ycmd--server-buffer-name "*ycmd-server*"
   "Name of the ycmd server buffer.")
 
-(defun ycmd--major-mode-to-file-types (mode)
-  "Map a major mode MODE to a list of file-types suitable for ycmd. 
+(defun ycmd-major-mode-to-file-types (mode)
+  "Map a major mode MODE to a list of file-types suitable for ycmd.
 
 If there is no established mapping, return nil."
   (cdr (assoc mode ycmd-file-type-map)))
@@ -899,7 +901,7 @@ nil, this uses the current buffer.
            (line-num (line-number-at-pos (point)))
            (full-path (or (buffer-file-name) ""))
            (file-contents (buffer-substring-no-properties (point-min) (point-max)))
-           (file-types (or (ycmd--major-mode-to-file-types major-mode)
+           (file-types (or (ycmd-major-mode-to-file-types major-mode)
                            '("generic"))))
       `(("file_data" .
          ((,full-path . (("contents" . ,file-contents)

--- a/ycmd.el
+++ b/ycmd.el
@@ -151,8 +151,8 @@ Options are:
 "
   :group 'ycmd
   :type '(set (const :tag "Load unknown extra confs" load)
-	      (const :tag "Ignore unknown extra confs" ignore)
-	      (const :tag "Ask the user" ask))
+              (const :tag "Ignore unknown extra confs" ignore)
+              (const :tag "Ask the user" ask))
   :risky t)
 
 (defcustom ycmd-host "127.0.0.1"
@@ -286,7 +286,7 @@ list
     (ruby-mode . ("ruby"))
     (scala-mode . ("scala"))
     (tuareg-mode . ("ocaml")))
-  "Mapping from major modes to ycmd file-type strings. 
+  "Mapping from major modes to ycmd file-type strings.
 
 Used to determine a) which major modes we support and b) how to
 describe them to ycmd."
@@ -339,7 +339,7 @@ This does nothing if no server is running."
 
   (unwind-protect
       (when (ycmd-running?)
-	(delete-process ycmd--server-process)))
+        (delete-process ycmd--server-process)))
 
   (ycmd--kill-notification-timer))
 
@@ -538,7 +538,7 @@ case this function returns 0.
 "
   (let ((buff (or buff (current-buffer))))
     (if (= col 0)
-	0
+        0
       (with-current-buffer buff
         (goto-line line)
         (forward-char (- col 1))
@@ -605,17 +605,17 @@ When clicked, this will popup MESSAGE."
 This is a fairly crude form of decoration, but it does give
 reasonable visual feedback on the problems found by ycmd."
   (ycmd--with-destructured-parse-result r
-   (--when-let (find-buffer-visiting filepath)
-     (with-current-buffer it
-       (let* ((start-pos (ycmd--line-start-position line-num))
-              (end-pos (ycmd--line-end-position line-num))
-              (btype (assoc-default kind ycmd--file-ready-buttons)))
-         (when btype
-           (with-silent-modifications
-             (ycmd--make-button
-              start-pos end-pos
-              btype
-              (concat kind ": " text)))))))))
+    (--when-let (find-buffer-visiting filepath)
+      (with-current-buffer it
+        (let* ((start-pos (ycmd--line-start-position line-num))
+               (end-pos (ycmd--line-end-position line-num))
+               (btype (assoc-default kind ycmd--file-ready-buttons)))
+          (when btype
+            (with-silent-modifications
+              (ycmd--make-button
+               start-pos end-pos
+               btype
+               (concat kind ": " text)))))))))
 
 (defun ycmd--display-error (msg)
   (message "ERROR: %s" msg))
@@ -699,29 +699,29 @@ functions in `ycmd-file-parse-result-hook'.
       (ycmd--report-status 'parsing)
 
       (deferred:$
-	;; try
-	(deferred:$
-	  ;; Make the request.
-	  (ycmd--request "/event_notification"
-			 content
-			 :parser 'json-read)
+        ;; try
+        (deferred:$
+          ;; Make the request.
+          (ycmd--request "/event_notification"
+                         content
+                         :parser 'json-read)
 
-	  (deferred:nextc it
-	    (lambda (results)
-	      (with-current-buffer buff
-		(ycmd--handle-notify-response results)))))
+          (deferred:nextc it
+            (lambda (results)
+              (with-current-buffer buff
+                (ycmd--handle-notify-response results)))))
 
-	;; catch
-	(deferred:error it
-	  (lambda (err)
-	    (message "Error sending notification request: %s" err)))
+        ;; catch
+        (deferred:error it
+          (lambda (err)
+            (message "Error sending notification request: %s" err)))
 
-	;; finally. As I understand it, this should always be
-	;; executed.
-    (deferred:nextc it
-      (lambda ()
-        (with-current-buffer buff
-          (ycmd--report-status 'parsed))))))))
+        ;; finally. As I understand it, this should always be
+        ;; executed.
+        (deferred:nextc it
+          (lambda ()
+            (with-current-buffer buff
+              (ycmd--report-status 'parsed))))))))
 
 (defun ycmd-display-raw-file-parse-results ()
   "Request file-parse results and display them in a buffer in raw form.
@@ -967,19 +967,19 @@ anything like that.)
 
     (deferred:$
 
-     (ycmd-request-deferred
-      (format "http://%s:%s%s" ycmd-host ycmd--server-actual-port location)
-      :headers `(("Content-Type" . "application/json")
-                 ("X-Ycm-Hmac" . ,encoded-hex-hmac))
-      :parser parser
-      :data content
-      :type type)
+      (ycmd-request-deferred
+       (format "http://%s:%s%s" ycmd-host ycmd--server-actual-port location)
+       :headers `(("Content-Type" . "application/json")
+                  ("X-Ycm-Hmac" . ,encoded-hex-hmac))
+       :parser parser
+       :data content
+       :type type)
 
-     (deferred:nextc it
-       (lambda (req)
-         (let ((content (ycmd-request-response-data req)))
-           (ycmd--log-content "HTTP RESPONSE CONTENT" content)
-           content))))))
+      (deferred:nextc it
+        (lambda (req)
+          (let ((content (ycmd-request-response-data req)))
+            (ycmd--log-content "HTTP RESPONSE CONTENT" content)
+            content))))))
 
 (defun ycmd--conditional-parse (&optional condition)
   "Reparse the buffer if CONDITION is in `ycmd-parse-conditions'
@@ -1089,3 +1089,7 @@ Hook `ycmd-mode' into modes in `ycmd-file-type-map'."
 (provide 'ycmd)
 
 ;;; ycmd.el ends here
+
+;; Local Variables:
+;; indent-tabs-mode: nil
+;; End:

--- a/ycmd.el
+++ b/ycmd.el
@@ -807,6 +807,11 @@ values. This produces output for empty alists that ycmd expects."
   (lambda (x) (secure-hash 'sha256 x nil nil 1))
   64 64)
 
+(defcustom ycmd-gocode-binary-path (executable-find "gocode")
+  "Gocode binary path."
+  :group 'ycmd
+  :type 'stringp)
+
 (defun ycmd--options-contents (hmac-secret)
   "Return a struct which can be JSON encoded into a file to
 create a ycmd options file.
@@ -819,7 +824,8 @@ file."
   (let ((hmac-secret (base64-encode-string hmac-secret))
         (global-config (or ycmd-global-config ""))
         (extra-conf-whitelist (or ycmd-extra-conf-whitelist []))
-        (max-num-identifier-candidates ycmd-max-num-identifier-candidates))
+        (max-num-identifier-candidates ycmd-max-num-identifier-candidates)
+        (gocode-binary-path (or ycmd-gocode-binary-path "")))
     `((filetype_blacklist (vimwiki . 1) (mail . 1) (qf . 1) (tagbar . 1) (unite . 1) (infolog . 1) (notes . 1) (text . 1) (pandoc . 1) (markdown . 1))
       (auto_start_csharp_server . 1)
       (filetype_whitelist (* . 1))
@@ -843,7 +849,8 @@ file."
       (min_num_of_chars_for_completion . 2)
       (filepath_completion_use_working_dir . 0)
       (semantic_triggers . ())
-      (auto_trigger . 1))))
+      (auto_trigger . 1)
+      (gocode_binary_path . ,gocode-binary-path))))
 
 (defun ycmd--create-options-file (hmac-secret)
   "This creates a new options file for a ycmd server.


### PR DESCRIPTION
Refactor company-ycmd to make it easier to add extended completion support for other languages and reduce language specific code in company-mode command functions like meta, annotation and post-completion. Increase maintainablity and scalability.