### PR TITLE
Add global-ycmd-mode and make ycmd-setup obsolete

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ To use `ycmd-mode` in all supported modes, add the following to your emacs confi
 
 ```emacs
 (require 'ycmd)
-(ycmd-setup)
+(add-hook 'after-init-hook #'global-ycmd-mode)
 ```
 
 Or add `ycmd-mode` to a specific supported mode:


### PR DESCRIPTION
A global mode simplifies setting up ycmd mode for multiple major-modes. The variable `ycmd-global-modes` specifies for which mode `ycmd-mode` is activated by `global-ycmd-mode`.