### PR TITLE
Depend on versioned ycmd for melpa stable

### DIFF
--- a/flycheck-ycmd.el
+++ b/flycheck-ycmd.el
@@ -4,7 +4,7 @@
 ;; Author: Austin Bingham <austin.bingham@gmail.com>
 ;; Version: 0.1
 ;; URL: https://github.com/abingham/emacs-ycmd
-;; Package-Requires: ((emacs "24") (dash "1.2.0") (flycheck "0.22") (ycmd "20141217.453"))
+;; Package-Requires: ((emacs "24") (dash "1.2.0") (flycheck "0.22") (ycmd "0.9"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
flycheck-ycmd is currently uninstallable from melpa stable due to an invalid version dependency.