### PR TITLE
Shutdown ycmd server with SIGINT

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -376,7 +376,7 @@ This does nothing if no server is running."
 
   (unwind-protect
       (when (ycmd-running?)
-        (delete-process ycmd--server-process)
+        (interrupt-process ycmd--server-process)
         (ycmd--global-teardown)))
 
   (ycmd--kill-timer ycmd--keepalive-timer))


### PR DESCRIPTION
The ycmd server expects to be shutdown cleanly with SIGTERM or SIGINT in
order to clean up temp files etc. Use interrupt-process instead of
delete-process in ycmd-close to terminate the ycmd process.

Fixes #201