### PR TITLE
Add option to set proxy settings

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -254,6 +254,14 @@ use `ycmd-parse-buffer'."
   :group 'ycmd
   :type 'boolean)
 
+(defcustom ycmd-bypass-url-proxy-services t
+  "Bypass proxies for local traffic with the ycmd server.
+
+If non-nil, bypass the variable `url-proxy-services' in
+`ycmd--request' by setting it to nil."
+  :group 'ycmd
+  :type 'boolean)
+
 (defcustom ycmd-tag-files nil
   "Whether to collect identifiers from tags file.
 
@@ -1245,6 +1253,8 @@ anything like that.)
   (unless (ycmd-running?) (ycmd-open))
 
   (let* ((url-show-status (not ycmd-hide-url-status))
+         (url-proxy-services (unless ycmd-bypass-url-proxy-services
+                               url-proxy-services))
          (ycmd-request-backend 'url-retrieve)
          (content (json-encode content))
          (hmac (ycmd--get-request-hmac type location content))


### PR DESCRIPTION
Allow to bypass proxy settings for the communication with the ycmd
server.

Resolves #235