### PR TITLE
Fix start server timeout

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -1304,7 +1304,8 @@ the name of the newly created file."
              (args (apply 'list (concat "--options_file=" options-file) ycmd-server-args))
              (server-program+args (append server-command args))
              (proc (apply #'start-process ycmd--server-process proc-buff server-program+args))
-             (cont 1))
+             (cont t)
+             (start-time (float-time)))
         (while cont
           (set-process-query-on-exit-flag proc nil)
           (accept-process-output proc 0 100 t)
@@ -1317,8 +1318,8 @@ the name of the newly created file."
                               (string-to-number (match-string 1 proc-output)))
                 (setq cont nil)))
              (t
-              (incf cont)
-              (when (< ycmd-startup-timeout cont) ; timeout after specified period
+              ;; timeout after specified period
+              (when (< (/ ycmd-startup-timeout 1000) (- (float-time) start-time))
                 (set-window-buffer nil proc-buff)
                 (error "Server timeout")
                 (ycmd--report-status 'errored))))))))))


### PR DESCRIPTION
`ycmd-server-timeout` was not used correctly because the variable `cont` was incremented by one every while loop iteration.

With this patch we set a start time and compare `ycmd-server-timeout` with the elapsed time.