### PR TITLE
Add eldoc support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,11 +39,11 @@ all : $(OBJECTS) $(OBJECTS_COMP) $(OBJECTS_FLYC) $(OBJECTS_ELDOC)
 
 ycmd : $(OBJECTS)
 
-company-ycmd : $(OBJECTS) $(OBJECTS_COMP)
+company-ycmd : ycmd $(OBJECTS_COMP)
 
-flycheck-ycmd : $(OBJECTS) $(OBJECTS_FLYC)
+flycheck-ycmd : ycmd $(OBJECTS_FLYC)
 
-ycmd-eldoc : $(OBJECTS) $(OBJECTS_ELDOC)
+ycmd-eldoc : ycmd $(OBJECTS_ELDOC)
 
 dist :
 	$(CASK) package

--- a/Makefile
+++ b/Makefile
@@ -23,22 +23,27 @@ OBJECTS_COMP = $(SRCS_COMP:.el=.elc)
 SRCS_FLYC = flycheck-ycmd.el
 OBJECTS_FLYC = $(SRCS_FLYC:.el=.elc)
 
+SRCS_ELDOC = ycmd-eldoc.el
+OBJECTS_ELDOC = $(SRCS_ELDOC:.el=.elc)
+
 DISTDIR = dist
 BUILDDIR = build
 
 EMACSBATCH = $(EMACS) -Q --batch $(EMACSFLAGS)
 
-.PHONY: deps all ycmd company-ycmd flycheck-ycmd dist test \
-	clean clean-elc clobber clobber-dist clobber-deps
+.PHONY: deps all ycmd company-ycmd flycheck-ycmd ycmd-eldoc dist \
+	test clean clean-elc clobber clobber-dist clobber-deps
 
 # Build targets
-all : $(OBJECTS) $(OBJECTS_COMP) $(OBJECTS_FLYC)
+all : $(OBJECTS) $(OBJECTS_COMP) $(OBJECTS_FLYC) $(OBJECTS_ELDOC)
 
 ycmd : $(OBJECTS)
 
 company-ycmd : $(OBJECTS) $(OBJECTS_COMP)
 
 flycheck-ycmd : $(OBJECTS) $(OBJECTS_FLYC)
+
+ycmd-eldoc : $(OBJECTS) $(OBJECTS_ELDOC)
 
 dist :
 	$(CASK) package
@@ -55,7 +60,7 @@ clean : clean-elc
 clobber: clobber-dist clobber-deps
 
 clean-elc :
-	rm -rf $(OBJECTS) $(OBJECTS_COMP) $(OBJECTS_FLYC)
+	rm -rf $(OBJECTS) $(OBJECTS_COMP) $(OBJECTS_FLYC) $(OBJECTS_ELDOC)
 
 clobber-dist :
 	rm -rf $(DISTDIR)

--- a/README.md
+++ b/README.md
@@ -175,6 +175,18 @@ The slightly longer and probably better answer is:
 
 For a full explanation see [the `emacs-ycmd` defect related to this](https://github.com/abingham/emacs-ycmd/issues/144) as well as [the root `flycheck` issue](https://github.com/flycheck/flycheck/issues/526).
 
+## `eldoc` integration
+
+`ycmd-eldoc` adds eldoc support for `ycmd-mode` buffers.
+
+``` emacs-lisp
+(require 'ycmd-eldoc)
+(add-hook 'ycmd-mode-hook 'ycmd-eldoc-setup)
+```
+
+Note: eldoc messages will only be shown for functions which are retrieved via semantic completion.
+
+
 ## `next-error` integration
 
 emacs-ycmd reports found errors through emacs buttons; to integrate those with

--- a/test/resources/test-eldoc.cpp
+++ b/test/resources/test-eldoc.cpp
@@ -1,0 +1,11 @@
+class Foo {
+public:
+    void bar(int x) {}
+};
+
+int main() {
+    Foo l;
+    l.bar()
+
+    return 0;
+}

--- a/test/run.el
+++ b/test/run.el
@@ -49,6 +49,7 @@
       (load (expand-file-name "ycmd" source-directory))
       (load (expand-file-name "company-ycmd" source-directory))
       (load (expand-file-name "flycheck-ycmd" source-directory))
+      (load (expand-file-name "ycmd-eldoc" source-directory))
       (load (expand-file-name "ycmd-test" (file-name-directory current-file))))
 
     (let* ((debug-on-error t)

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -167,27 +167,27 @@ response."
 (ycmd-ert-deftest get-completions-python "test.py" 'python-mode
   ;; :disabled t ;; TODO Find out why this fails sometimes
   :line 7 :column 3
-  (ycmd-with-deferred-request 'ycmd-get-completions
-    (let ((start-col (assoc-default 'completion_start_column response))
-          (completions (assoc-default 'completions response)))
-      (should (cl-some (lambda (c)
-                         (string-equal
-                          "a" (assoc-default 'insertion_text c)))
-                       completions))
-      (should (cl-some (lambda (c)
-                         (string-equal
-                          "b" (assoc-default 'insertion_text c)))
-                       completions))
-      (should (= start-col 3)))))
+  (let* ((response (ycmd-get-completions :sync))
+         (start-col (assoc-default 'completion_start_column response))
+         (completions (assoc-default 'completions response)))
+    (should (cl-some (lambda (c)
+                       (string-equal
+                        "a" (assoc-default 'insertion_text c)))
+                     completions))
+    (should (cl-some (lambda (c)
+                       (string-equal
+                        "b" (assoc-default 'insertion_text c)))
+                     completions))
+    (should (= start-col 3))))
 
 (ycmd-ert-deftest get-completions-go "test.go" 'go-mode
   :line 9 :column 10
-  (ycmd-with-deferred-request 'ycmd-get-completions
-    (let* ((start-col (assoc-default 'completion_start_column response))
-           (completions (assoc-default 'completions response))
-           (c (nth 0 (append completions nil))))
-      (should (string= "Logger" (assoc-default 'insertion_text c)))
-      (should (= start-col 6)))))
+  (let* ((response (ycmd-get-completions :sync))
+         (start-col (assoc-default 'completion_start_column response))
+         (completions (assoc-default 'completions response))
+         (c (nth 0 (append completions nil))))
+    (should (string= "Logger" (assoc-default 'insertion_text c)))
+    (should (= start-col 6))))
 
 (defun ycmd-test-fixit-handler (response file-name)
   (let ((ycmd-confirm-fixit nil)

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -56,6 +56,7 @@
 (require 'company-ycmd)
 (require 'flycheck-ert)
 (require 'flycheck-ycmd)
+(require 'ycmd-eldoc)
 (require 'macroexp)
 
 (defconst ycmd-test-location
@@ -71,6 +72,7 @@
   "Setup `ycmd-mode' for test in current buffer."
   (let ((ycmd-parse-conditions nil))
     (ycmd-mode)
+    (ycmd-open)
     (deferred:sync!
       (ycmd-load-conf-file ycmd-test-extra-conf))
     (deferred:sync!
@@ -94,17 +96,15 @@ evaluating BODY."
      (ycmd-test-mode)
      ,@body))
 
-(defmacro ycmd-ert-deftest-deferred-request (name filename mode
-                                                  &rest keys-and-body)
+(defmacro ycmd-ert-deftest (name filename mode &rest keys-and-body)
   "Define a test case for a deferred request to the ycmd server.
 
 NAME is a symbol denoting the local name of the test.  The test
 itself is named `ycmd-test-NAME'.  FILENAME is the input file with
-the `major-mode' MODE.  The rest should contain the keywords
-`:request-func' specifying the function with the request to the
-ycmd server.  `:line' and `:column' is the file location for the
-request.  The remaining forms of KEYS-AND-BODY are used to
-evaluate the server's response."
+the `major-mode' MODE.  The rest should contain keywords.  `:line'
+and `:column' is the file location for the request.  The remaining
+forms of KEYS-AND-BODY are used to evaluate the server's
+response."
   (declare (indent 3) (debug t))
   (let* ((full-name (intern (format "ycmd-test-%s" name)))
          (keys-and-body (ert--parse-keys-and-body keys-and-body))
@@ -119,68 +119,75 @@ evaluate the server's response."
                   ,(plist-get keys :line)
                   (current-buffer))))
            (goto-char current-position)
-           (deferred:sync!
-             (deferred:$
-               (funcall ,(plist-get keys :request-func))
-               (deferred:nextc it
-                 (lambda (response)
-                   ,@body)))))))))
+           ,@body)))))
 
-(ycmd-ert-deftest-deferred-request get-completions-cpp "test.cpp" 'c++-mode
-  :request-func 'ycmd-get-completions
+(defmacro ycmd-with-deferred-request (request-func body)
+  "Run a request with REQUEST-FUNC and eval BODY with response."
+  (declare (indent 1))
+  `(deferred:sync!
+     (deferred:$
+       (funcall ,request-func)
+       (deferred:nextc it
+         (lambda (response)
+           ,(macroexpand-all body))))))
+
+(ycmd-ert-deftest get-completions-cpp "test.cpp" 'c++-mode
   :line 8 :column 7
-  (let ((start-col (assoc-default 'completion_start_column response))
-        (completions (assoc-default 'completions response)))
+  (let* ((response (ycmd-get-completions :sync))
+         (start-col (assoc-default 'completion_start_column response))
+         (completions (assoc-default 'completions response)))
     (should (cl-some (lambda (c)
                        (string-equal
                         "llurp" (assoc-default 'insertion_text c)))
                      completions))
     (should (= start-col 7))))
 
-(ycmd-ert-deftest-deferred-request goto-declaration "test-goto.cpp" 'c++-mode
-  :request-func (apply-partially #'ycmd--send-completer-command-request
-                                 "GoToDeclaration")
+(ycmd-ert-deftest goto-declaration "test-goto.cpp" 'c++-mode
   :line 9 :column 7
-  (if (assoc-default 'exception response)
-      (should nil)
-    (progn
-      (should (= (assoc-default 'column_num response) 10))
-      (should (= (assoc-default 'line_num response) 2)))))
+  (ycmd-with-deferred-request
+      (apply-partially #'ycmd--send-completer-command-request
+                       "GoToDeclaration")
+    (if (assoc-default 'exception response)
+        (should nil)
+      (progn
+        (should (= (assoc-default 'column_num response) 10))
+        (should (= (assoc-default 'line_num response) 2))))))
 
-(ycmd-ert-deftest-deferred-request goto-definition "test-goto.cpp" 'c++-mode
-  :request-func (apply-partially #'ycmd--send-completer-command-request
-                                 "GoToDefinition")
+(ycmd-ert-deftest goto-definition "test-goto.cpp" 'c++-mode
   :line 9 :column 7
-  (if (assoc-default 'exception response)
-      (should nil)
-    (progn
-      (should (= (assoc-default 'column_num response) 11))
-      (should (= (assoc-default 'line_num response) 5)))))
+  (ycmd-with-deferred-request
+      (apply-partially #'ycmd--send-completer-command-request
+                       "GoToDefinition")
+    (if (assoc-default 'exception response)
+        (should nil)
+      (progn
+        (should (= (assoc-default 'column_num response) 11))
+        (should (= (assoc-default 'line_num response) 5))))))
 
-(ycmd-ert-deftest-deferred-request get-completions-python "test.py" 'python-mode
-  :disabled t ;; TODO Find out why this fails sometimes
-  :request-func 'ycmd-get-completions
+(ycmd-ert-deftest get-completions-python "test.py" 'python-mode
+  ;; :disabled t ;; TODO Find out why this fails sometimes
   :line 7 :column 3
-  (let ((start-col (assoc-default 'completion_start_column response))
-        (completions (assoc-default 'completions response)))
-    (should (cl-some (lambda (c)
-                       (string-equal
-                        "a" (assoc-default 'insertion_text c)))
-                     completions))
-    (should (cl-some (lambda (c)
-                       (string-equal
-                        "b" (assoc-default 'insertion_text c)))
-                     completions))
-    (should (= start-col 3))))
+  (ycmd-with-deferred-request 'ycmd-get-completions
+    (let ((start-col (assoc-default 'completion_start_column response))
+          (completions (assoc-default 'completions response)))
+      (should (cl-some (lambda (c)
+                         (string-equal
+                          "a" (assoc-default 'insertion_text c)))
+                       completions))
+      (should (cl-some (lambda (c)
+                         (string-equal
+                          "b" (assoc-default 'insertion_text c)))
+                       completions))
+      (should (= start-col 3)))))
 
-(ycmd-ert-deftest-deferred-request get-completions-go "test.go" 'go-mode
-  :request-func 'ycmd-get-completions
+(ycmd-ert-deftest get-completions-go "test.go" 'go-mode
   :line 9 :column 10
-  (let* ((start-col (assoc-default 'completion_start_column response))
-         (completions (assoc-default 'completions response))
-         (c (nth 0 (append completions nil))))
-    (should (string= "Logger" (assoc-default 'insertion_text c)))
-    (should (= start-col 6))))
+  (ycmd-with-deferred-request 'ycmd-get-completions
+    (let* ((start-col (assoc-default 'completion_start_column response))
+           (completions (assoc-default 'completions response))
+           (c (nth 0 (append completions nil))))
+      (should (string= "Logger" (assoc-default 'insertion_text c)))
+      (should (= start-col 6)))))
 
 (defun ycmd-test-fixit-handler (response file-name)
   (let ((ycmd-confirm-fixit nil)
@@ -197,15 +204,14 @@ evaluate the server's response."
   (declare (indent 2) (debug t))
   (let* ((line (plist-get keys :line))
          (column (plist-get keys :column)))
-    `(ycmd-ert-deftest-deferred-request
-         ,name ,(plist-get keys :filename) ,mode
-       :request-func
-       (apply-partially #'ycmd--send-completer-command-request
-                        "FixIt")
+    `(ycmd-ert-deftest ,name ,(plist-get keys :filename) ,mode
        :line ,line :column ,column
-       (should
-        (ycmd-test-fixit-handler
-         response ,(plist-get keys :filename-expected))))))
+       (ycmd-with-deferred-request
+           ',(apply-partially
+              #'ycmd--send-completer-command-request "FixIt")
+         (should
+          (ycmd-test-fixit-handler
+           response ,(plist-get keys :filename-expected)))))))
 
 (ycmd-ert-deftest-fixit fixit-cpp-insert1 'c++-mode
   :filename "test-fixit-cpp11-insert1.cpp"
@@ -476,6 +482,14 @@ evaluate the server's response."
 
 (flycheck-ert-initialize ycmd-test-resources-location)
 
+(ycmd-ert-deftest eldoc-info-at-point-on-keyword "test-eldoc.cpp" 'c++-mode
+  :line 8 :column 8
+  (should (equal (substring-no-properties (ycmd-eldoc--info-at-point))
+                 "void bar( int x )")))
+(ycmd-ert-deftest eldoc-info-at-point-between-par "test-eldoc.cpp" 'c++-mode
+  :line 8 :column 11
+  (should (equal (substring-no-properties (ycmd-eldoc--info-at-point))
+                 "void bar( int x )")))
 
 (provide 'ycmd-test)
 

--- a/ycmd-eldoc.el
+++ b/ycmd-eldoc.el
@@ -1,0 +1,119 @@
+;;; ycmd-eldoc.el --- Eldoc support for ycmd-mode    -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2016  Peter Vasil
+
+;; Author: Peter Vasil <mail@petervasil.net>
+;; URL: https://github.com/abingham/emacs-ycmd
+;; Version: 0.1
+;; Package-Requires: ((ycmd "0.1") (deferred "0.2.0") (s "1.9.0") (dash "1.2.0") (cl-lib "0.5"))
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; To use this package, add these lines to your init.el file:
+;;
+;;     (require 'ycmd-eldoc)
+;;     (add-hook 'ycmd-mode-hook 'ycmd-eldoc-setup)
+;;
+
+;;; Code:
+
+(require 'cl-lib)
+(require 'eldoc)
+(require 'ycmd)
+(require 'deferred)
+(require 'dash)
+(require 's)
+
+
+(defvar-local ycmd-eldoc--cache nil)
+
+(defun ycmd-eldoc--documentation-function ()
+  "Eldoc function for `ycmd-mode'."
+  (when ycmd-mode
+    (--when-let (ycmd-eldoc--info-at-point)
+      (eldoc-message it))))
+
+(defun ycmd-eldoc--info-at-point ()
+  "Get function info at point."
+  (save-excursion
+    (ycmd-eldoc--goto-func-name)
+    (-when-let (symbol (symbol-at-point))
+      (if (eq symbol (car ycmd-eldoc--cache))
+          (cadr ycmd-eldoc--cache)
+        (deferred:sync!
+          (deferred:$
+            (ycmd-get-completions)
+            (deferred:nextc it
+              (lambda (completions)
+                (-when-let* ((candidates
+                              (assoc-default 'completions completions))
+                             (text (ycmd-eldoc--generate-message
+                                    (symbol-name symbol) candidates)))
+                  (setq text (ycmd--fontify-code text))
+                  (setq ycmd-eldoc--cache (list symbol text))
+                  text)))))))))
+
+(defun ycmd-eldoc--goto-func-name ()
+  "If point is inside a function call, move to the function name.
+foo(bar, |baz); -> foo|(bar, baz);"
+  (let ((last-paren-pos (nth 1 (syntax-ppss)))
+        (start-pos (point)))
+    (when last-paren-pos
+      ;; Move to just before the last paren.
+      (goto-char last-paren-pos)
+      ;; If we're inside a round paren, we're inside a function call.
+      (unless (looking-at "(")
+        ;; Otherwise, return to our start position, as point may have been on a
+        ;; function already:
+        ;; foo|(bar, baz);
+        (goto-char start-pos)))))
+
+(defun ycmd-eldoc--generate-message (symbol result)
+  "Generate eldoc message for SYMBOL from RESULT."
+  (-when-let* ((filtered-list
+                (cl-remove-if-not
+                 (lambda (val)
+                   (let ((text (assoc-default 'insertion_text val))
+                         (extra-info (assoc-default 'extra_menu_info val)))
+                     (and (s-equals? text symbol)
+                          (or (not extra-info)
+                              (not (-contains?
+                                    '("[ID]" "[File]" "[Dir]" "[File&Dir]")
+                                    extra-info))))))
+                 ;; Convert vector to list
+                 (append result nil)))
+               (item (car filtered-list))
+               (msg (or (assoc-default 'detailed_info item)
+                        (assoc-default 'extra_menu_info item))))
+    (unless (s-blank? msg)
+      (car (s-split-up-to "\n" msg 1)))))
+
+;;;###autoload
+(defun ycmd-eldoc-setup ()
+  "Setup eldoc for `ycmd-mode'."
+  (interactive)
+  (add-function :before-until (local 'eldoc-documentation-function)
+                #'ycmd-eldoc--documentation-function)
+  (eldoc-mode +1))
+
+(advice-add 'ycmd--teardown :after
+            (lambda ()
+              "Reset ycmd-eldoc--cache on `ycmd--teardown'"
+              (setq ycmd-eldoc--cache nil)))
+
+(provide 'ycmd-eldoc)
+
+;;; ycmd-eldoc.el ends here

--- a/ycmd-eldoc.el
+++ b/ycmd-eldoc.el
@@ -62,6 +62,7 @@
           (setq ycmd-eldoc--cache (list symbol text))
           text)))))
 
+;; Source: https://github.com/racer-rust/emacs-racer/blob/master/racer.el
 (defun ycmd-eldoc--goto-func-name ()
   "If point is inside a function call, move to the function name.
 foo(bar, |baz); -> foo|(bar, baz);"

--- a/ycmd-eldoc.el
+++ b/ycmd-eldoc.el
@@ -53,18 +53,14 @@
     (-when-let (symbol (symbol-at-point))
       (if (eq symbol (car ycmd-eldoc--cache))
           (cadr ycmd-eldoc--cache)
-        (deferred:sync!
-          (deferred:$
-            (ycmd-get-completions)
-            (deferred:nextc it
-              (lambda (completions)
-                (-when-let* ((candidates
-                              (assoc-default 'completions completions))
-                             (text (ycmd-eldoc--generate-message
-                                    (symbol-name symbol) candidates)))
-                  (setq text (ycmd--fontify-code text))
-                  (setq ycmd-eldoc--cache (list symbol text))
-                  text)))))))))
+        (-when-let* ((completions (ycmd-get-completions :sync))
+                     (candidates
+                      (assoc-default 'completions completions))
+                     (text (ycmd-eldoc--generate-message
+                            (symbol-name symbol) candidates)))
+          (setq text (ycmd--fontify-code text))
+          (setq ycmd-eldoc--cache (list symbol text))
+          text)))))
 
 (defun ycmd-eldoc--goto-func-name ()
   "If point is inside a function call, move to the function name.


### PR DESCRIPTION
This patch adds basic eldoc support for `ycmd-mode` enabled buffers.

Some constraints:

* works only for keywords after a semantic trigger because else only identifier based completion candidates without any further information are returned from `ycmd` server.
* Showing the current argument bold when entering function arguments (see eldoc in `emacs-lisp-mode`)
* `ycmd-get-completions` call is synchronous
* might be slow when using in large c++ projects

There is definately room for improvements but I think it works already pretty well

@abingham What do you think?