### PR TITLE
Allow identifier completion while file being parsed

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -369,16 +369,12 @@ candidates list."
 
 (defun company-ycmd--prefix ()
   "Prefix-command handler for the company backend."
-  (when (ycmd-parsing-in-progress-p)
-    (message "Ycmd completion unavailable while parsing is in progress."))
-
   (and ycmd-mode
        buffer-file-name
        (ycmd-running?)
        (or (not (company-in-string-or-comment))
            (company-ycmd--in-include))
-       (or (and (not (ycmd-parsing-in-progress-p))
-                (company-grab-symbol-cons "\\.\\|->\\|::" 2))
+       (or (company-grab-symbol-cons "\\.\\|->\\|::" 2)
            'stop)))
 
 (defun company-ycmd--candidates (prefix)

--- a/ycmd.el
+++ b/ycmd.el
@@ -851,10 +851,6 @@ To see what the returned structure looks like, you can use
 `ycmd-display-completions'."
   (with-current-buffer buffer
     (goto-char pos)
-
-    (when (ycmd-parsing-in-progress-p)
-      (message "Ycmd completion unavailable while parsing is in progress."))
-
     (when ycmd-mode
       (let* ((extra-content (and ycmd-force-semantic-completion
                                  'force-semantic))


### PR DESCRIPTION
With recent `ycmd` it is possible to retrieve identifier completion while file being parsed. This patch removes the `ycmd-parsing-in-progress-p` checks