### PR TITLE
Get completion candidates in company-ycmd synchronously

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -95,6 +95,12 @@ feature."
   :type 'boolean
   :group 'company-ycmd)
 
+(defcustom company-ycmd-request-sync-timeout 0.05
+  "Timeout for synchronous ycmd completion request.
+When 0, do not use synchronous completion request at all."
+  :type 'number
+  :group 'company-ycmd)
+
 (defconst company-ycmd--extended-features-modes
   '(c++-mode c-mode go-mode objc-mode rust-mode)
   "Major modes which have extended features in `company-ycmd'.")
@@ -308,31 +314,40 @@ candidates list."
     ("rust" 'company-ycmd--construct-candidate-rust)
     (_ 'company-ycmd--construct-candidate-generic)))
 
-(defun company-ycmd--get-candidates (cb prefix)
-  "Call CB with completion candidates for PREFIX at the current point."
-  (deferred:$
+(defun company-ycmd--get-candidates (completions prefix &optional cb)
+  "Get candidates for COMPLETIONS and PREFIX.
 
+If CB is non-nil, call it with candidates."
+  (if (assoc-default 'exception completions)
+      (let ((msg (assoc-default 'message c nil "unknown error")))
+        (message "Exception while fetching candidates: %s" msg)
+        '())
+    (funcall
+     (or cb 'identity)
+     (company-ycmd--construct-candidates
+      (assoc-default 'completions completions)
+      prefix
+      (assoc-default 'completion_start_column completions)
+      (company-ycmd--get-construct-candidate-fn)))))
+
+(defun company-ycmd--get-candidates-synchronously (prefix)
+  "Get completion candidates with PREFIX synchronously."
+  (--when-let (and (ycmd-running?)
+                   (ycmd-get-completions
+                    (current-buffer) (point) :sync))
+    (company-ycmd--get-candidates it prefix)))
+
+(defun company-ycmd--get-candidates-deferred (prefix cb)
+  "Get completion candidates with PREFIX and call CB deferred."
+  (deferred:$
     (deferred:try
       (deferred:$
-        (if (ycmd-running?)
-            (ycmd-get-completions (current-buffer) (point))))
+        (when (ycmd-running?)
+          (ycmd-get-completions (current-buffer) (point))))
       :catch (lambda (err) nil))
-
     (deferred:nextc it
       (lambda (c)
-        (if (assoc-default 'exception c)
-
-            (let ((msg (assoc-default 'message c nil "unknown error")))
-              (message "Exception while fetching candidates: %s" msg)
-              '())
-
-          (funcall
-           cb
-           (company-ycmd--construct-candidates
-            (assoc-default 'completions c)
-            prefix
-            (assoc-default 'completion_start_column c)
-            (company-ycmd--get-construct-candidate-fn))))))))
+        (company-ycmd--get-candidates c prefix cb)))))
 
 (defun company-ycmd--meta (candidate)
   "Fetch the metadata text-property from a CANDIDATE string."
@@ -369,22 +384,26 @@ candidates list."
 
 (defun company-ycmd--prefix ()
   "Prefix-command handler for the company backend."
-  (when (ycmd-parsing-in-progress-p)
-    (message "Ycmd completion unavailable while parsing is in progress."))
-
   (and ycmd-mode
        buffer-file-name
        (ycmd-running?)
        (or (not (company-in-string-or-comment))
            (company-ycmd--in-include))
-       (or (and (not (ycmd-parsing-in-progress-p))
-                (company-grab-symbol-cons "\\.\\|->\\|::" 2))
+       (or (company-grab-symbol-cons "\\.\\|->\\|::" 2)
            'stop)))
 
 (defun company-ycmd--candidates (prefix)
-  "Candidates-command handler for the company backend."
-  (cons :async (lambda (cb)
-                 (company-ycmd--get-candidates cb prefix))))
+  "Candidates-command handler for the company backend for PREFIX."
+  (let ((async-fetcher
+         (cons :async
+               (lambda (cb)
+                 (company-ycmd--get-candidates-deferred prefix cb)))))
+    (if (> company-ycmd-request-sync-timeout 0)
+        (with-timeout
+            (company-ycmd-request-sync-timeout
+             async-fetcher)
+          (company-ycmd--get-candidates-synchronously prefix))
+      async-fetcher)))
 
 (defun company-ycmd--post-completion (candidate)
   "Insert function arguments after completion for CANDIDATE."
@@ -432,7 +451,7 @@ candidates list."
 
 ;;;###autoload
 (defun company-ycmd-setup ()
-  "Add company-ycmd to the front of company-backends"
+  "Add company-ycmd to the front of company-backends."
   (add-to-list 'company-backends 'company-ycmd))
 
 (provide 'company-ycmd)

--- a/ycmd.el
+++ b/ycmd.el
@@ -6,7 +6,7 @@
 ;;          Peter Vasil <mail@petervasil.net>
 ;; Version: 0.9.1
 ;; URL: https://github.com/abingham/emacs-ycmd
-;; Package-Requires: ((emacs "24") (f "0.17.1") (dash "1.2.0") (deferred "0.3.2") (popup "0.5.0"))
+;; Package-Requires: ((emacs "24") (f "0.17.1") (dash "1.2.0") (deferred "0.3.2") (popup "0.5.0") (cl-lib "0.5"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -103,6 +103,8 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'cl-lib))
 (require 'dash)
 (require 'deferred)
 (require 'f)
@@ -823,7 +825,7 @@ Returns the new value of `ycmd-force-semantic-completion'."
         symbols
       (cdr (assq symbols ycmd-keywords-alist)))))
 
-(defun ycmd-get-completions (buffer pos)
+(defun ycmd-get-completions (buffer pos &optional sync)
   "Get completions in BUFFER for position POS from the ycmd server.
 
 Returns a deferred object which yields the HTTP message
@@ -851,10 +853,6 @@ To see what the returned structure looks like, you can use
 `ycmd-display-completions'."
   (with-current-buffer buffer
     (goto-char pos)
-
-    (when (ycmd-parsing-in-progress-p)
-      (message "Ycmd completion unavailable while parsing is in progress."))
-
     (when ycmd-mode
       (let* ((extra-content (and ycmd-force-semantic-completion
                                  'force-semantic))
@@ -863,7 +861,8 @@ To see what the returned structure looks like, you can use
         (ycmd--request
          "/completions"
          content
-         :parser 'json-read)))))
+         :parser 'json-read
+         :sync sync)))))
 
 (defun ycmd--handle-exception (results)
   "Handle exception in completion RESULTS.
@@ -1672,9 +1671,12 @@ This is useful for debugging.")
               `(,method ,path ,(or body "")) "")
    ycmd--hmac-secret))
 
-(defun* ycmd--request (location
-                       content
-                       &key (parser 'buffer-string) (type "POST"))
+(cl-defun ycmd--request (location
+                         content
+                         &key
+                         (parser 'buffer-string)
+                         (type "POST")
+                         (sync nil))
   "Send an asynchronous HTTP request to the ycmd server.
 
 This starts the server if necessary.
@@ -1703,24 +1705,40 @@ anything like that.)
          (ycmd-request-backend 'url-retrieve)
          (content (json-encode content))
          (hmac (ycmd--get-request-hmac type location content))
-         (encoded-hmac (base64-encode-string hmac 't)))
+         (encoded-hmac (base64-encode-string hmac 't))
+         (url (format "http://%s:%s%s"
+                      ycmd-host ycmd--server-actual-port location))
+         (headers `(("Content-Type" . "application/json")
+                    ("X-Ycm-Hmac" . ,encoded-hmac))))
     (ycmd--log-content "HTTP REQUEST CONTENT" content)
 
-    (deferred:$
-
-      (ycmd-request-deferred
-       (format "http://%s:%s%s" ycmd-host ycmd--server-actual-port location)
-       :headers `(("Content-Type" . "application/json")
-                  ("X-Ycm-Hmac" . ,encoded-hmac))
-       :parser parser
-       :data content
-       :type type)
-
-      (deferred:nextc it
-        (lambda (req)
-          (let ((content (ycmd-request-response-data req)))
-            (ycmd--log-content "HTTP RESPONSE CONTENT" content)
-            content))))))
+    (if sync
+        (let (result)
+          (ycmd-request
+           url
+           :headers headers
+           :parser parser
+           :data content
+           :type type
+           :sync t
+           :success
+           (cl-function
+            (lambda (&key data &allow-other-keys)
+              (ycmd--log-content "HTTP RESPONSE CONTENT" data)
+              (setq result data))))
+          result)
+      (deferred:$
+        (ycmd-request-deferred
+         url
+         :headers headers
+         :parser parser
+         :data content
+         :type type)
+        (deferred:nextc it
+          (lambda (req)
+            (let ((content (ycmd-request-response-data req)))
+              (ycmd--log-content "HTTP RESPONSE CONTENT" content)
+              content)))))))
 
 (provide 'ycmd)
 


### PR DESCRIPTION
Using a hybrid solution for `company-ycmd`. All requests are asynchronous except for `ycmd-get-completions` which can be call synchronously.

If `company-ycmd-request-sync-timeout` is larger than `0` get completions synchronously. If there is no result within the time range of the timeout, call `ycmd-get-completions` asynchronously.