### PR TITLE
Use current-buffer and point in ycmd-get-completions

### DIFF
--- a/auto-complete-ycmd.el
+++ b/auto-complete-ycmd.el
@@ -71,7 +71,7 @@
 (defun ac-ycmd-candidates ()
   "Get the list of completions at point."
   (if (ycmd-running?)
-      (let ((completions (assoc-default 'completions (ycmd-get-completions (point)))))
+      (let ((completions (assoc-default 'completions (ycmd-get-completions))))
         (mapcar (lambda (c) (cdr (assoc 'insertion_text c))) completions))
     nil))
   ;; (if (ycmd-running?)

--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -381,8 +381,7 @@ If CB is non-nil, call it with candidates."
 (defun company-ycmd--get-candidates-synchronously (prefix)
   "Get completion candidates with PREFIX synchronously."
   (--when-let (and (ycmd-running?)
-                   (ycmd-get-completions
-                    (current-buffer) (point) :sync))
+                   (ycmd-get-completions :sync))
     (company-ycmd--get-candidates it prefix)))
 
 (defun company-ycmd--get-candidates-deferred (prefix cb)
@@ -391,7 +390,7 @@ If CB is non-nil, call it with candidates."
     (deferred:try
       (deferred:$
         (when (ycmd-running?)
-          (ycmd-get-completions (current-buffer) (point))))
+          (ycmd-get-completions)))
       :catch (lambda (err) nil))
     (deferred:nextc it
       (lambda (c)


### PR DESCRIPTION
Remove the `buffer` and `pos` function arguments from `ycmd-get-completions` since it was added for the tests. There are now new helper macros `ycmd-ert-with-temp-buffer` and `ycmd-ert-with-resource-buffer` which can be used to set up the buffer for the tests. The usage of `ycmd-get-completions` outside the tests was always using `(current-buffer)` and `(point)`. By removing the parameters the interface gets a bit simpler.