### PR TITLE
pcase takes upatterns

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -356,7 +356,7 @@ candidates list."
 (defun company-ycmd--get-construct-candidate-fn ()
   "Return function to construct candidate(s) for current `major-mode'."
   (pcase (car-safe (ycmd-major-mode-to-file-types major-mode))
-    ((or "cpp" "c" "objc") 'company-ycmd--construct-candidate-clang)
+    ((or `"cpp" `"c" `"objc") 'company-ycmd--construct-candidate-clang)
     ("go" 'company-ycmd--construct-candidate-go)
     ("python" 'company-ycmd--construct-candidate-python)
     ("rust" 'company-ycmd--construct-candidate-rust)


### PR DESCRIPTION
On at least Emacs 24.3, one sees completions that are just basenames, i.e. "foo" instead of "foo(int)". That's because ...
  (pcase "a"
      ((or "a" "b") "unsurprising")
      (_ "surprising"))
... yields "surprising".
On 25, it looks like things are unsurprising.
Backquoting the strings (to make them "upatterns" in pcase parlance) fixes the problem.