### PR TITLE
Improve compatibility of ycmd-running? with older Emacsen.

### DIFF
--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -491,6 +491,9 @@ response."
   (should (equal (substring-no-properties (ycmd-eldoc--info-at-point))
                  "void bar( int x )")))
 
+(ert-deftest ycmd-test-not-running ()
+  (should-not (ycmd-running?)))
+
 (provide 'ycmd-test)
 
 ;;; ycmd-test.el ends here

--- a/ycmd.el
+++ b/ycmd.el
@@ -785,11 +785,11 @@ process with `delete-process'."
     (error nil)))
 
 (defun ycmd-running? ()
-  "Return non-nil if a ycmd server is already running."
-  (let ((process (get-process ycmd--server-process)))
+  "Return t if a ycmd server is already running."
+  (-when-let (process (get-process ycmd--server-process))
     (and (processp process)
-         (memq (process-status process)
-               '(run open listen connect stop)))))
+         (process-live-p process)
+         t)))
 
 (defun ycmd--keepalive ()
   "Sends an unspecified message to the server.


### PR DESCRIPTION
Older Emacsen don't accept nil as argument to process-live-p.  Use more
conditions to work around this.

While there, make ycmd-running? fulfill its contract by returning
t (instead of any non-nil) on success.