### PR TITLE
Use package let-alist to silence warnings and simplify code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ dist :
 	$(CASK) package
 
 # Test targets
-test : $(OBJECTS) $(OBJECTS_COMP) $(OBJECTS_FLYC)
+test : $(OBJECTS) $(OBJECTS_COMP) $(OBJECTS_FLYC) $(OBJECTS_ELDOC)
 	$(EMACSBATCH) --script test/run.el '$(YCMDPATH)' '$(ERTSELECTOR)'
 
 # Support targets

--- a/flycheck-ycmd.el
+++ b/flycheck-ycmd.el
@@ -4,7 +4,7 @@
 ;; Author: Austin Bingham <austin.bingham@gmail.com>
 ;; Version: 0.1
 ;; URL: https://github.com/abingham/emacs-ycmd
-;; Package-Requires: ((emacs "24") (dash "1.2.0") (flycheck "0.22") (ycmd "0.9"))
+;; Package-Requires: ((emacs "24") (dash "1.2.0") (flycheck "0.22") (ycmd "0.9") (let-alist "1.0.4"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -46,6 +46,8 @@
 ;;
 ;;; Code:
 
+(eval-when-compile
+  (require 'let-alist))
 (require 'dash)
 (require 'flycheck)
 (require 'ycmd)
@@ -62,16 +64,16 @@
 
 (defun flycheck-ycmd--result-to-error (result checker)
   "Convert ycmd parse RESULT for CHECKER into a flycheck error object."
-  (ycmd--with-destructured-parse-result result
-    (if (string-equal filepath (buffer-file-name))
+  (let-alist result
+    (if (string-equal .location.filepath (buffer-file-name))
         (flycheck-error-new
-         :line line-num
-         :column column-num
+         :line .location.line_num
+         :column .location.column_num
          :buffer (current-buffer)
-         :filename filepath
-         :message (concat text (when (eq fixit-available t) " (FixIt)"))
+         :filename .location.filepath
+         :message (concat .text (when (eq .fixit_available t) " (FixIt)"))
          :checker checker
-         :level (assoc-default kind flycheck-ycmd--level-map 'string-equal 'error)))))
+         :level (assoc-default .kind flycheck-ycmd--level-map 'string-equal 'error)))))
 
 (defun flycheck-ycmd--start (checker callback)
   "Start ycmd flycheck CHECKER using CALLBACK to communicate with flycheck."

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -301,7 +301,7 @@ response."
       (should (ycmd-test-has-property-with-value
                'return_type "(n int, err error)" candidate)))))
 
-(ert-deftest company-ycmd-test-contruct-candidate-python ()
+(ert-deftest company-ycmd-test-construct-candidate-python ()
   (ycmd-ert-with-temp-buffer 'python-mode
     (let* ((data '((insertion_text . "foo")
                    (detailed_info . "foo(self, a, b)\n\nA function")

--- a/ycmd-eldoc.el
+++ b/ycmd-eldoc.el
@@ -5,7 +5,7 @@
 ;; Author: Peter Vasil <mail@petervasil.net>
 ;; URL: https://github.com/abingham/emacs-ycmd
 ;; Version: 0.1
-;; Package-Requires: ((ycmd "0.1") (deferred "0.2.0") (s "1.9.0") (dash "1.2.0") (cl-lib "0.5"))
+;; Package-Requires: ((ycmd "0.1") (deferred "0.2.0") (s "1.9.0") (dash "1.2.0") (cl-lib "0.5") (let-alist "1.0.4))
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
@@ -30,6 +30,8 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'let-alist))
 (require 'cl-lib)
 (require 'eldoc)
 (require 'ycmd)
@@ -83,13 +85,12 @@ foo(bar, |baz); -> foo|(bar, baz);"
   (-when-let* ((filtered-list
                 (cl-remove-if-not
                  (lambda (val)
-                   (let ((text (assoc-default 'insertion_text val))
-                         (extra-info (assoc-default 'extra_menu_info val)))
-                     (and (s-equals? text symbol)
-                          (or (not extra-info)
+                   (let-alist val
+                     (and (s-equals? .insertion_text symbol)
+                          (or (not .extra_menu_info)
                               (not (-contains?
                                     '("[ID]" "[File]" "[Dir]" "[File&Dir]")
-                                    extra-info))))))
+                                    .extra_menu_info))))))
                  ;; Convert vector to list
                  (append result nil)))
                (item (car filtered-list))


### PR DESCRIPTION
Use let-alist instead of binding all variables when parsing ycmd result
structures. let-alist binds only variables which are used in body.

This makes the code a bit simpler because we don't need to bind all variables from result manually.