### PR TITLE
Switch back to upstream request package

### DIFF
--- a/Cask
+++ b/Cask
@@ -3,14 +3,14 @@
 
 (package-file "ycmd.el")
 
-(files "ycmd.el" "third-party/ycmd-request.el"
-       "third-party/ycmd-request-deferred.el"
-       "contrib/ycmd-next-error.el")
+(files "ycmd.el" "contrib/ycmd-next-error.el")
 
 (depends-on "f")
 (depends-on "dash")
 (depends-on "deferred")
 (depends-on "popup")
+(depends-on "request")
+(depends-on "request-deferred")
 
 (development
  (depends-on "company")

--- a/Makefile
+++ b/Makefile
@@ -10,10 +10,7 @@ PKGDIR := $(shell EMACS=$(EMACS) $(CASK) package-directory)
 # Export the used EMACS to recipe environments
 export EMACS
 
-SRCS = ycmd.el \
-	third-party/ycmd-request.el \
-	third-party/ycmd-request-deferred.el \
-	contrib/ycmd-next-error.el
+SRCS = ycmd.el contrib/ycmd-next-error.el
 
 OBJECTS = $(SRCS:.el=.elc)
 
@@ -73,6 +70,4 @@ $(PKGDIR) : Cask
 	touch $(PKGDIR)
 
 %.elc : %.el $(PKGDIR)
-	$(CASK) exec $(EMACSBATCH) \
-		--eval "(add-to-list 'load-path \"${PWD}/third-party\")" \
-		-L . -f batch-byte-compile $<
+	$(CASK) exec $(EMACSBATCH) -L . -f batch-byte-compile $<

--- a/test/run.el
+++ b/test/run.el
@@ -44,8 +44,6 @@
              emacs-version (format-time-string "%F" emacs-build-time))
 
     (let ((debug-on-error t))
-      (load (expand-file-name "third-party/ycmd-request" source-directory))
-      (load (expand-file-name "third-party/ycmd-request-deferred" source-directory))
       (load (expand-file-name "ycmd" source-directory))
       (load (expand-file-name "company-ycmd" source-directory))
       (load (expand-file-name "flycheck-ycmd" source-directory))

--- a/ycmd.el
+++ b/ycmd.el
@@ -6,7 +6,7 @@
 ;;          Peter Vasil <mail@petervasil.net>
 ;; Version: 0.9.1
 ;; URL: https://github.com/abingham/emacs-ycmd
-;; Package-Requires: ((emacs "24") (f "0.17.1") (dash "1.2.0") (deferred "0.3.2") (popup "0.5.0") (cl-lib "0.5") (let-alist "1.0.4"))
+;; Package-Requires: ((emacs "24.3") (dash "2.12.1") (deferred "0.3.2") (popup "0.5.0") (cl-lib "0.5") (let-alist "1.0.4") (request "0.2.0") (request-deferred "0.2.0"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;
@@ -112,15 +112,10 @@
 (require 'hmac-def)
 (require 'json)
 (require 'popup)
-;; (require 'request)
-;; (require 'request-deferred)
+(require 'request)
+(require 'request-deferred)
 (require 'etags)
 
-;; Allow loading of our bundled third-party modules
-(add-to-list 'load-path (f-join (f-dirname (f-this-file)) "third-party"))
-
-(require 'ycmd-request)
-(require 'ycmd-request-deferred)
 
 (defgroup ycmd nil
   "a ycmd emacs client"
@@ -1727,7 +1722,7 @@ anything like that.)
   (let* ((url-show-status (not ycmd-hide-url-status))
          (url-proxy-services (unless ycmd-bypass-url-proxy-services
                                url-proxy-services))
-         (ycmd-request-backend 'url-retrieve)
+         (request-backend 'url-retrieve)
          (content (json-encode content))
          (hmac (ycmd--get-request-hmac type location content))
          (encoded-hmac (base64-encode-string hmac 't))
@@ -1739,7 +1734,7 @@ anything like that.)
 
     (if sync
         (let (result)
-          (ycmd-request
+          (request
            url :headers headers :parser parser :data content :type type
            :sync t
            :success
@@ -1749,11 +1744,11 @@ anything like that.)
               (setq result data))))
           result)
       (deferred:$
-        (ycmd-request-deferred
+        (request-deferred
          url :headers headers :parser parser :data content :type type)
         (deferred:nextc it
           (lambda (req)
-            (let ((content (ycmd-request-response-data req)))
+            (let ((content (request-response-data req)))
               (ycmd--log-content "HTTP RESPONSE CONTENT" content)
               content)))))))
 


### PR DESCRIPTION
Use upstream `request` and `request-deferred` package instead of `ycmd-request` and `ycmd-request-deferred`. Keep `third-party` folder until MELPA recipe is updated to not download files from `third-party`