### PR TITLE
Fix local binding of json-encode-keyword

### DIFF
--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -515,6 +515,11 @@ response."
 (ert-deftest ycmd-test-not-running ()
   (should-not (ycmd-running?)))
 
+(ert-deftest ycmd-test-json-encode ()
+  (let ((data '((foo))))
+    (should (string= (ycmd--json-encode data)
+                     "{\"foo\":{}}"))))
+
 (provide 'ycmd-test)
 
 ;;; ycmd-test.el ends here

--- a/ycmd.el
+++ b/ycmd.el
@@ -1594,9 +1594,10 @@ If there is no established mapping, return nil."
   "Encode a json object OBJ.
 A version of json-encode that uses {} instead of null for nil values.
 This produces output for empty alists that ycmd expects."
-  (cl-flet ((json-encode-keyword (k) (cond ((eq k t)          "true")
-                                           ((eq k json-false) "false")
-                                           ((eq k json-null)  "{}"))))
+  (cl-letf (((symbol-function 'json-encode-keyword)
+             (lambda (k) (cond ((eq k t)          "true")
+                               ((eq k json-false) "false")
+                               ((eq k json-null)  "{}")))))
     (json-encode obj)))
 
 ;; This defines 'ycmd--hmac-function which we use to combine an HMAC


### PR DESCRIPTION
`cl-flet` does not work here for the intended functionality. `cl-flet` does
not bind the function recursively. It's only overridden within the
`cl-flet` binding but not inside `json-encode`. Use `cl-letf` construct as
`flet` replacement.