### PR TITLE
Add after teardown hook

### DIFF
--- a/flycheck-ycmd.el
+++ b/flycheck-ycmd.el
@@ -59,7 +59,7 @@
   '(("ERROR" . error)
     ("WARNING" . warning)))
 
-(defvar flycheck-ycmd--cache nil
+(defvar-local flycheck-ycmd--cache nil
   "Cache for parse results.")
 
 (defun flycheck-ycmd--result-to-error (result checker)
@@ -106,12 +106,17 @@ display."
 This adds a hook to watch for ycmd parse results, and it adds the
 ycmd checker to the list of flycheck checkers."
   (add-hook 'ycmd-file-parse-result-hook 'flycheck-ycmd--cache-parse-results)
-  (add-to-list 'flycheck-checkers 'ycmd))
+  (add-to-list 'flycheck-checkers 'ycmd)
+  (add-hook 'ycmd-after-teardown-hook #'flycheck-ycmd--teardown))
 
 (flycheck-define-generic-checker 'ycmd
   "A flycheck checker using parse results from ycmd."
   :start #'flycheck-ycmd--start
   :predicate #'flycheck-ycmd--in-supported-mode)
+
+(defun flycheck-ycmd--teardown ()
+  "Reset `flycheck-ycmd--cache'."
+  (setq flycheck-ycmd--cache nil))
 
 (provide 'flycheck-ycmd)
 

--- a/ycmd-eldoc.el
+++ b/ycmd-eldoc.el
@@ -132,10 +132,11 @@ foo(bar, |baz); -> foo|(bar, baz);"
                     #'ycmd-eldoc--documentation-function)
     (set (make-local-variable 'eldoc-documentation-function)
          'ycmd-eldoc--documentation-function))
+  (add-hook 'ycmd-after-teardown-hook #'ycmd-eldoc--teardown)
   (eldoc-mode +1))
 
-(defadvice ycmd--teardown (after ycmd-teardown-after activate)
-  "Reset ycmd-eldoc--cache on `ycmd--teardown'."
+(defun ycmd-eldoc--teardown ()
+  "Reset `ycmd-eldoc--cache'."
   (setq ycmd-eldoc--cache nil))
 
 (provide 'ycmd-eldoc)

--- a/ycmd.el
+++ b/ycmd.el
@@ -386,6 +386,13 @@ This variable is a normal hook.  See Info node `(elisp)Hooks'."
   :type 'hook
   :risky t)
 
+(defcustom ycmd-after-teardown-hook nil
+  "Functions to run after execution of `ycmd--teardown'.
+
+This variable is a normal hook.  See Info node `(elisp)Hooks'."
+  :type 'hook
+  :risky t)
+
 (defconst ycmd--diagnostic-file-types
   '("c"
     "cpp"
@@ -732,7 +739,8 @@ _LEN is ununsed."
 (defun ycmd--teardown ()
   "Teardown ycmd in current buffer."
   (ycmd--kill-timer ycmd--notification-timer)
-  (setq ycmd--last-status-change 'unparsed))
+  (setq ycmd--last-status-change 'unparsed)
+  (run-hooks 'ycmd-after-teardown-hook))
 
 (defun ycmd--global-teardown ()
   "Teardown ycmd in all buffers."


### PR DESCRIPTION
Add a hook in `ycmd--teardown` which can be used to reset stuff in other packages like `ycmd-eldoc` or `flycheck-ycmd`. In `ycmd-eldoc` resetting was done by advising `ycmd--teardown` but that does not scale well. Make `flycheck-ycmd--cache` buffer local and add a `flycheck-ycmd--teardown` function to reset the cache whenever `ycmd--teardown` is called.