### PR TITLE
Do not set request-backend to url-retrieve

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -1863,7 +1863,6 @@ anything like that.)
   (let* ((url-show-status (not ycmd-hide-url-status))
          (url-proxy-services (unless ycmd-bypass-url-proxy-services
                                url-proxy-services))
-         (request-backend 'url-retrieve)
          (content (json-encode content))
          (hmac (ycmd--get-request-hmac type location content))
          (encoded-hmac (base64-encode-string hmac 't))
@@ -1879,12 +1878,13 @@ anything like that.)
 
     (if sync
         (let (result)
-          (request
-           url :headers headers :parser parser :data content :type type
-           :sync t
-           :complete
-           (lambda (&rest args)
-             (setq result (funcall response-fn (plist-get args :response)))))
+          (with-local-quit
+            (request
+             url :headers headers :parser parser :data content :type type
+             :sync t
+             :complete
+             (lambda (&rest args)
+               (setq result (funcall response-fn (plist-get args :response))))))
           result)
       (deferred:$
         (request-deferred


### PR DESCRIPTION
Don't force using `url-retrieve` as `request-backend`. The user might
want to use `curl` as `request-backend`.

At the time of this commit there is an Emacs bug with `url-retrieve` and
non-ascii characters in the request:
http://debbugs.gnu.org/cgi/bugreport.cgi?bug=24117#23

To work around the bug the `request-backend` can be set to `curl`.

When sending the request synchronously while using `curl`, Emacs prints
a Warning (`Blocking call to accept-process-output with quit
inhibited!!`). To suppress the warning we need to surround the
blocking `request` call with `with-local-quit` to make quitting the
process with `C-g` work.

Resolves #323 