### PR TITLE
Wait for server ready state after process start

### DIFF
--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -182,7 +182,7 @@ response."
 
 (ycmd-ert-deftest get-completions-python "test.py" 'python-mode
   :line 7 :column 3
-  (skip-unless nil)
+  ;; (skip-unless nil)
   (let ((response (ycmd-get-completions :sync)))
     (let-alist response
       (should (cl-some (lambda (c)

--- a/ycmd.el
+++ b/ycmd.el
@@ -169,6 +169,10 @@ Example value:
   "Extra arguments to pass to the ycmd server."
   :type '(repeat string))
 
+(defcustom ycmd-server-port nil
+  "The ycmd server port.  If nil, use random port."
+  :type '(number))
+
 (defcustom ycmd-file-parse-result-hook nil
   "Functions to run with file-parse results.
 
@@ -492,13 +496,14 @@ Keywords source: https://github.com/auto-complete/auto-complete/tree/master/dict
 
 (defvar ycmd--server-actual-port 0
   "The actual port being used by the ycmd server.
-This is set based on the output from the server itself.")
+This is set based on the value of `ycmd-server-port' or the
+return value of `ycmd--get-unused-port'.")
 
 (defvar ycmd--hmac-secret nil
   "This is populated with the hmac secret of the current connection.
 Users should never need to modify this, hence the defconst.  It is
-not, however, treated as a constant by this code.  This value
-gets set in ycmd-open.")
+not, however, treated as a constant by this code.  This value gets
+set in ycmd-open.")
 
 (defconst ycmd--server-process-name "ycmd-server"
   "The Emacs name of the server process.
@@ -766,15 +771,12 @@ diagnostics) for MODE."
   "Start a new ycmd server.
 
 This kills any ycmd server already running (under ycmd.el's
-control.) The newly started server will have a new HMAC secret."
+control.)."
   (interactive)
-
   (ycmd-close)
-
-  (let ((hmac-secret (ycmd--generate-hmac-secret)))
-    (when (ycmd--start-server hmac-secret)
-      (setq ycmd--hmac-secret hmac-secret)
-      (ycmd--start-keepalive-timer))))
+  (ycmd--start-server)
+  (when (ycmd--wait-until-server-ready)
+    (ycmd--start-keepalive-timer)))
 
 (defun ycmd-close ()
   "Shutdown any running ycmd server.
@@ -812,7 +814,25 @@ process with `delete-process'."
   "Sends an unspecified message to the server.
 
 This is simply for keepalive functionality."
-  (ycmd--request "/healthy" '() :type "GET"))
+  (ycmd--request "/healthy" nil :type "GET"))
+
+(defun ycmd--server-ready? (&optional include-subserver)
+  "Send request for server ready state.
+
+If INCLUDE-SUBSERVER is non-nil, also request ready state for
+semantic subserver."
+  (let ((file-type
+         (and include-subserver
+              (car-safe (ycmd-major-mode-to-file-types
+                         major-mode))))
+        (request-message-level -1)
+        (request-log-level -1))
+    (ignore-errors
+      (ycmd--request
+       "/ready" nil
+       :params (and file-type
+                    (list (cons "subserver" file-type)))
+       :type "GET" :parser 'json-read :sync t))))
 
 (defun ycmd-load-conf-file (filename)
   "Tell the ycmd server to load the configuration file FILENAME."
@@ -1734,6 +1754,19 @@ the name of the newly created file."
       (insert (ycmd--json-encode options)))
     options-file))
 
+(defun ycmd--get-unused-port ()
+  "Return unused localhost port."
+  (let* ((p (make-network-process
+             :name "get-unused-port"
+             :server t
+             :service t
+             :host "127.0.0.1"))
+         (port (process-contact p :service)))
+    (when p (delete-process p))
+    (unless port
+      (error "Could not retrive unused localhost port"))
+    port))
+
 (defun ycmd--exit-code-as-string (code)
   "Return exit status message for CODE."
   (pcase code
@@ -1762,8 +1795,8 @@ the name of the newly created file."
       (ycmd--with-all-ycmd-buffers
         (ycmd--report-status status)))))
 
-(defun ycmd--start-server (hmac-secret)
-  "Start a new server using HMAC-SECRET."
+(defun ycmd--start-server ()
+  "Start a new server and return the process."
   (unless ycmd-server-command
     (user-error "Error: The variable `ycmd-server-command' is not set.  \
 See the docstring of the variable for an example"))
@@ -1771,35 +1804,46 @@ See the docstring of the variable for an example"))
     (with-current-buffer proc-buff
       (buffer-disable-undo)
       (erase-buffer))
-    (let* ((options-file (ycmd--create-options-file hmac-secret))
-           (args (apply 'list (concat "--options_file=" options-file)
+    (let* ((port (or (and (numberp ycmd-server-port)
+                          (> ycmd-server-port 0))
+                     (ycmd--get-unused-port)))
+           (hmac-secret (ycmd--generate-hmac-secret))
+           (options-file (ycmd--create-options-file hmac-secret))
+           (args (apply 'list (format "--port=%d" port)
+                        (concat "--options_file=" options-file)
                         ycmd-server-args))
            (server-program+args (append ycmd-server-command args))
            (proc (apply #'start-process ycmd--server-process-name proc-buff
-                        server-program+args))
-           (server-start-time (float-time))
-           time-since-server-start server-started)
+                        server-program+args)))
       (set-process-query-on-exit-flag proc nil)
       (set-process-sentinel proc #'ycmd--server-process-sentinel)
-      (while (and (not server-started) (ycmd-running?))
-        (accept-process-output proc 0 100 t)
-        (let ((proc-output (with-current-buffer proc-buff
-                             (buffer-string))))
-          (cond
-           ((string-match "^serving on http://.*:\\\([0-9]+\\\)$" proc-output)
-            (setq ycmd--server-actual-port
-                  (string-to-number (match-string 1 proc-output)))
-            (ycmd--with-all-ycmd-buffers (ycmd--report-status 'unparsed))
+      (setq ycmd--server-actual-port port)
+      (setq ycmd--hmac-secret hmac-secret)
+      proc)))
+
+(defun ycmd--wait-until-server-ready ()
+  "Wait until server is ready.
+
+Return t when server is ready.  Signal error in case of timeout.
+The timeout can be set with the variable
+`ycmd-startup-timeout'."
+  (let ((server-start-time (float-time))
+         server-started)
+    (while (and (not server-started) (ycmd-running?))
+      (sit-for 0.1)
+      (if (ycmd--server-ready? :include-subserver)
+          (progn
+            (ycmd--with-all-ycmd-buffers
+              (ycmd--report-status 'unparsed))
             (setq server-started t))
-           (t
-            ;; timeout after specified period
-            (setq time-since-server-start (- (float-time) server-start-time))
-            (when (> time-since-server-start ycmd-startup-timeout)
-              (ycmd-close)
-              (ycmd--with-all-ycmd-buffers
-                (ycmd--report-status 'errored))
-              (error "ERROR: Ycmd server timeout"))))))
-      server-started)))
+        ;; timeout after specified period
+        (when (< ycmd-startup-timeout
+                 (- (float-time) server-start-time))
+          (ycmd-close)
+          (ycmd--with-all-ycmd-buffers
+            (ycmd--report-status 'errored))
+          (error "ERROR: Ycmd server timeout"))))
+    server-started))
 
 (defun ycmd--column-in-bytes ()
   "Calculate column offset in bytes for the current position and buffer."
@@ -1922,6 +1966,7 @@ This is useful for debugging.")
                          &key
                          (parser 'buffer-string)
                          (type "POST")
+                         (params nil)
                          (sync nil))
   "Send an asynchronous HTTP request to the ycmd server.
 
@@ -1966,14 +2011,15 @@ anything like that.)
           (with-local-quit
             (request
              url :headers headers :parser parser :data content :type type
-             :sync t
+             :sync t :params params
              :complete
              (lambda (&rest args)
                (setq result (funcall response-fn (plist-get args :response))))))
           result)
       (deferred:$
         (request-deferred
-         url :headers headers :parser parser :data content :type type)
+         url :headers headers :parser parser :data content :type type
+         :params params)
         (deferred:nextc it
           response-fn)))))
 


### PR DESCRIPTION
This patch improves the whole process of starting the server.

- Split `ycmd--start-server` function into two funcitons, one for creating the process object and another for waiting for the server to be ready
- Don't parse the output of the server to be sure it's started. Instead use the server ready request at location `/ready`. With an argument the subserver (jedi, rust, go..) is also queried. In order to do this we must specify the server port ourselves because we don't parse it anymore from the server output. This way the python completion unit test is not failing anymore on travis. (The jedi subserver took a bit longer to start and we already tried to complete and failed). 
- Also add option for the user to set the port.