### PR TITLE
Increase keepalive timer interval

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -184,7 +184,7 @@ re-parsing the contents."
   :type '(number)
   :safe #'numberp)
 
-(defcustom ycmd-keepalive-period 30
+(defcustom ycmd-keepalive-period 600
   "Number of seconds between keepalive messages."
   :type '(number))
 


### PR DESCRIPTION
We set the idle time for the server to quit after inactivity with `idle_suicide_seconds` to 3 hours. I think it's it's ok to increase the keepalive interval to 10 minutes.