### PR TITLE
Ignore generics when inserting Rust function arguments

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -524,9 +524,9 @@ If CB is non-nil, call it with candidates."
                    company-ycmd-insert-arguments
                    (get-text-property 0 'params candidate))
     (when (memq major-mode '(python-mode rust-mode))
-      (setq it (company-ycmd--remove-self-from-function-args it)))
-    (when (eq major-mode 'rust-mode)
-      (setq it (company-ycmd--remove-template-args-from-function-args it)))
+      (setq it (company-ycmd--remove-self-from-function-args it))
+      (when (eq major-mode 'rust-mode)
+        (setq it (company-ycmd--remove-template-args-from-function-args it))))
     (insert it)
     (if (string-match "\\`:[^:]" it)
         (company-template-objc-templatify it)

--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -243,7 +243,6 @@ overloaded functions."
 
 (defun company-ycmd--remove-template-args-from-function-args (args)
   "Remove template arguments from ARGS string."
-  (message "%s" args)
   (if (s-starts-with? "<" args)
       (substring args (+ 1 (s-index-of ">" args)))
     args))

--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -230,7 +230,7 @@ overloaded functions."
                   'meta meta 'kind kind 'params params))))
 
 (defun company-ycmd--remove-self-from-function-args (args)
-  "Remove function argument `self' from ARGS list."
+  "Remove function argument `self' from ARGS string."
   (if (s-contains? "self" args)
       (when (string-match "(\\(.*\\))" args)
         (->> (s-split "," (match-string 1 args) t)
@@ -239,6 +239,13 @@ overloaded functions."
              (s-trim-left)
              (s-prepend (substring args 0 (match-beginning 1)))
              (s-append (substring args (match-end 1)))))
+    args))
+
+(defun company-ycmd--remove-template-args-from-function-args (args)
+  "Remove template arguments from ARGS string."
+  (message "%s" args)
+  (if (s-starts-with? "<" args)
+      (substring args (+ 1 (s-index-of ">" args)))
     args))
 
 (defun company-ycmd--extract-params-python (function-sig function-name)
@@ -519,6 +526,8 @@ If CB is non-nil, call it with candidates."
                    (get-text-property 0 'params candidate))
     (when (memq major-mode '(python-mode rust-mode))
       (setq it (company-ycmd--remove-self-from-function-args it)))
+    (when (eq major-mode 'rust-mode)
+      (setq it (company-ycmd--remove-template-args-from-function-args it)))
     (insert it)
     (if (string-match "\\`:[^:]" it)
         (company-template-objc-templatify it)

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -602,6 +602,11 @@ response."
     (should (equal (company-ycmd--remove-self-from-function-args data)
                    "(a, b)"))))
 
+(ert-deftest company-ycmd-test-remove-template-args-from-function-args ()
+  (let ((data "<'a, T>(a, b)"))
+    (should (equal (company-ycmd--remove-template-args-from-function-args data)
+                   "(a, b)"))))
+
 (ert-deftest company-ycmd-test-extract-params-python-simple ()
   (let ((data "foo(self, a, b)"))
     (should (equal (company-ycmd--extract-params-python data "foo")


### PR DESCRIPTION
Generic parameters are almost always inferred, and the inserted syntax wasn't valid anyway.

This special-casing is a bit hackish though, perhaps the string to insert should instead be constructed by `construct-candidate-*` and saved in the candidate separately?