### PR TITLE
Use pp to print debug info

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -2097,7 +2097,9 @@ This is useful for debugging.")
                            (deferred:nextc it
                              (lambda (result)
                                result)))))
-            (princ it)
+            (princ (with-temp-buffer
+                     (cl-prettyprint it)
+                     (buffer-string)))
           (princ "No debug info available from server"))
         (princ "\n\n")
         (princ "Server is ")


### PR DESCRIPTION
The ycmd server returns now a dictionary for debug_info instead of a
string.

See: https://github.com/Valloric/ycmd/pull/601
