### PR TITLE
Cache ycmd installation on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: emacs-lisp
 cache:
   directories:
     - .cask/
+    - $HOME/.ccache
+    - $HOME/ycmd
+    - $HOME/.npm  # Node packages from npm
+
 env:
   matrix:
     # Run unit tests against oldest supported stable, latest stable, and trunk
@@ -16,18 +20,14 @@ before_install:
   - if [[ -n $EMACS_VERSION ]]; then emacs --version; fi
 
   # ycmd
-  - git clone --depth=1 --recursive https://github.com/Valloric/ycmd
-  - cd ycmd
-  - python build.py --clang-completer --gocode-completer --tern-completer
-  - npm install -g typescript
-  - cd ..
+  - travis/install_ycmd.sh
 
 install:
   - if [[ -n $EMACS_VERSION ]]; then make deps; fi
 script:
   - if [[ -n $EMACS_VERSION ]]; then make all; fi
-  - if [[ -n $EMACS_VERSION ]]; then make YCMDPATH="ycmd/ycmd" REQUEST_BACKEND=url-retrieve test; fi
-  - if [[ -n $EMACS_VERSION ]]; then make YCMDPATH="ycmd/ycmd" REQUEST_BACKEND=curl test; fi
+  - if [[ -n $EMACS_VERSION ]]; then make YCMDPATH="$HOME/ycmd/ycmd" REQUEST_BACKEND=url-retrieve test; fi
+  - if [[ -n $EMACS_VERSION ]]; then make YCMDPATH="$HOME/ycmd/ycmd" REQUEST_BACKEND=curl test; fi
 matrix:
   # Finish the build even if any build with allowed failures are still running
   fast_finish: true

--- a/test/run.el
+++ b/test/run.el
@@ -55,7 +55,10 @@
       (load (expand-file-name "ycmd-test" (file-name-directory ycmd-runner-file))))
 
     (let* ((debug-on-error t)
-           (ycmd-path (expand-file-name (pop argv) source-directory))
+           (ycmd-path-raw (pop argv))
+           (ycmd-path (if (f-absolute? ycmd-path-raw)
+                          ycmd-path-raw
+                        (expand-file-name ycmd-path-raw source-directory)))
            (ycmd-server-command (list python-path ycmd-path))
            (ert-selector (pop argv))
            (ycmd-request-backend (intern (pop argv)))

--- a/travis/install_ycmd.sh
+++ b/travis/install_ycmd.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+export YCMD_PATH="${HOME}/ycmd"
+
+if [ ! -d "$YCMD_PATH/.git" ]; then
+  git clone --depth=1 --recursive https://github.com/Valloric/ycmd ${YCMD_PATH}
+fi
+
+pushd ${YCMD_PATH}
+
+git pull
+git submodule update --init --recursive
+
+export EXTRA_CMAKE_ARGS="-DCMAKE_CXX_COMPILER=/usr/lib/ccache/c++ -DCMAKE_C_COMPILER=/usr/lib/ccache/cc"
+python build.py --clang-completer --gocode-completer --tern-completer
+
+npm install -g typescript
+
+popd


### PR DESCRIPTION
Speed up compilation on travis by caching ycmd installation.

This saves a couple of minutes of build time when rebuilding a branch. 