### PR TITLE
Start server without blocking

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -448,8 +448,7 @@ If CB is non-nil, call it with candidates."
 
 (defun company-ycmd--get-candidates-synchronously (prefix)
   "Get completion candidates with PREFIX synchronously."
-  (--when-let (and (ycmd-running?)
-                   (ycmd-get-completions :sync))
+  (--when-let (ycmd-get-completions :sync)
     (company-ycmd--get-candidates it prefix)))
 
 (defun company-ycmd--get-candidates-deferred (prefix cb)
@@ -461,8 +460,7 @@ If CB is non-nil, call it with candidates."
     (deferred:$
       (deferred:try
         (deferred:$
-          (when (ycmd-running?)
-            (ycmd-get-completions)))
+          (ycmd-get-completions))
         :catch (lambda (_err) nil))
       (deferred:nextc it
         (lambda (c)

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -76,8 +76,9 @@
 (defun ycmd-test-mode ()
   "Setup `ycmd-mode' for test in current buffer."
   (let ((ycmd-parse-conditions nil))
-    (ycmd-mode)
     (ycmd-open)
+    (ycmd-wait-until-server-is-ready)
+    (ycmd-mode)
     (deferred:sync!
       (ycmd-load-conf-file ycmd-test-extra-conf))
     (deferred:sync!


### PR DESCRIPTION
Start server asynchronously without blocking Emacs.

Use process filter to parse port from buffer for parsing the port asynchronously. Discard all requests until server is fully started and don't start server in `ycmd--request` anymore.

Waiting for the server to start is only required in the unit test.

Resolves #369 