### PR TITLE
Use list as json-array-type

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -386,11 +386,11 @@ with spaces."
   "Generic function to construct completion string from a CANDIDATE."
   (company-ycmd--with-destructured-candidate candidate .insertion_text))
 
-(defun company-ycmd--construct-candidates (completion-vector
+(defun company-ycmd--construct-candidates (completions
                                            prefix
                                            start-col
                                            construct-candidate-fn)
-  "Construct candidates list from COMPLETION-VECTOR.
+  "Construct candidates list from COMPLETIONS.
 
 PREFIX is the prefix we calculated for doing the completion, and
 START-COL is the column on which ycmd indicates we should place
@@ -407,7 +407,7 @@ candidates list."
          (prefix-size (- start-col prefix-start-col))
          (prefix-diff (substring-no-properties prefix 0 prefix-size))
          candidates)
-    (dolist (candidate (append completion-vector nil) (nreverse candidates))
+    (dolist (candidate completions (nreverse candidates))
       (when (s-present? prefix-diff)
         (let ((it (assq 'insertion_text candidate)))
           (setcdr it (concat prefix-diff

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -195,7 +195,7 @@ response."
   :line 9 :column 10
   (let ((response (ycmd-get-completions :sync)))
     (let-alist response
-      (let ((c (nth 0 (append .completions nil))))
+      (let ((c (nth 0 .completions)))
         (should (string= "Logger" (cdr (assq 'insertion_text c))))
         (should (= .completion_start_column 6))))))
 
@@ -218,19 +218,19 @@ response."
                        .completions)))))
 
 (ert-deftest ycmd-test-fixit-same-location-false ()
-  (let ((data '(((chunks . [((replacement_text . "foo"))])
+  (let ((data '(((chunks . (((replacement_text . "foo"))))
                  (location (filepath . "test.cpp")
                            (column_num . 1) (line_num . 2)))
-                ((chunks . [((replacement_text . "bar"))])
+                ((chunks . (((replacement_text . "bar"))))
                  (location (filepath . "test.cpp")
                            (column_num . 3) (line_num . 4))))))
     (should-not (ycmd--fixits-have-same-location-p data))))
 
 (ert-deftest ycmd-test-fixit-same-location-true ()
-  (let ((data '(((chunks . [((replacement_text . "foo"))])
+  (let ((data '(((chunks . (((replacement_text . "foo"))))
                  (location (filepath . "test.cpp")
                            (column_num . 1) (line_num . 2)))
-                ((chunks . [((replacement_text . "bar"))])
+                ((chunks . (((replacement_text . "bar"))))
                  (location (filepath . "test.cpp")
                            (column_num . 1) (line_num . 2))))))
     (should (ycmd--fixits-have-same-location-p data))))
@@ -320,7 +320,7 @@ response."
 
 (ert-deftest ycmd-test-refactor-rename-simple ()
   (let* ((file-path (f-join ycmd-test-resources-location "simple_test.js"))
-         (data `((fixits . [((chunks . [((range
+         (data `((fixits . (((chunks . (((range
                                           (start (filepath . ,file-path) (column_num . 5) (line_num . 1))
                                           (end (filepath . ,file-path) (column_num . 22) (line_num . 1)))
                                          (replacement_text . "test"))
@@ -343,9 +343,9 @@ response."
                                         ((range
                                           (start (filepath . ,file-path) (column_num . 28) (line_num . 21))
                                           (end (filepath . ,file-path) (column_num . 45) (line_num . 21)))
-                                         (replacement_text . "test"))])
+                                         (replacement_text . "test"))))
                              (text . "")
-                             (location (filepath . ,file-path) (column_num . 34) (line_num . 15)))]))))
+                             (location (filepath . ,file-path) (column_num . 34) (line_num . 15))))))))
     (should (ycmd-test-refactor-rename-handler
              data '(("simple_test.js" . "simple_test-expected.js"))))))
 
@@ -353,7 +353,7 @@ response."
   (let* ((file-path-1 (f-join ycmd-test-resources-location "file1.js"))
          (file-path-2 (f-join ycmd-test-resources-location "file2.js"))
          (file-path-3 (f-join ycmd-test-resources-location "file3.js"))
-         (data `((fixits . [((chunks . [((range
+         (data `((fixits . (((chunks . (((range
                                           (start (filepath . ,file-path-1) (column_num . 5) (line_num . 1))
                                           (end (filepath . ,file-path-1) (column_num . 11) (line_num . 1)))
                                          (replacement_text . "test"))
@@ -368,9 +368,9 @@ response."
                                         ((range
                                           (start (filepath . ,file-path-3) (column_num . 12) (line_num . 3))
                                           (end (filepath . ,file-path-3) (column_num . 18) (line_num . 3)))
-                                         (replacement_text . "test"))])
+                                         (replacement_text . "test"))))
                              (text . "")
-                             (location (filepath . ,file-path-1) (column_num . 5) (line_num . 1)))]))))
+                             (location (filepath . ,file-path-1) (column_num . 5) (line_num . 1))))))))
     (should (ycmd-test-refactor-rename-handler
              data '(("file1.js" . "file1-expected.js")
                     ("file2.js" . "file2-expected.js")
@@ -747,6 +747,11 @@ response."
   (let ((data '((foo))))
     (should (string= (ycmd--json-encode data)
                      "{\"foo\":{}}"))))
+
+(ert-deftest ycmd-test-location-data-predicate ()
+  (let ((data '((filepath . ,file-path) (column_num . 34) (line_num . 15))))
+    (should (ycmd--location-data? data))
+    (should-not (ycmd--location-data? (list data)))))
 
 (defun flycheck-ycmd-test-mode ()
   (flycheck-ycmd-setup)

--- a/ycmd-eldoc.el
+++ b/ycmd-eldoc.el
@@ -116,8 +116,7 @@ foo(bar, |baz); -> foo|(bar, baz);"
                               (not (-contains?
                                     '("[ID]" "[File]" "[Dir]" "[File&Dir]")
                                     .extra_menu_info))))))
-                 ;; Convert vector to list
-                 (append result nil)))
+                 result))
                (item (car filtered-list))
                (msg (or (cdr (assq 'detailed_info item))
                         (cdr (assq 'extra_menu_info item)))))


### PR DESCRIPTION
With using list as json array type, there is no need to convert the
result vector into list in many places.