### PR TITLE
Check if subcommand is available for completer

### DIFF
--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -138,6 +138,48 @@ response."
       (lambda (response)
         ,(macroexpand-all body)))))
 
+(ycmd-ert-deftest get-defined-subcommands-cpp "test.cpp" 'c++-mode
+  :line 1 :column 1
+  (let ((commands '("ClearCompilationFlagCache" "FixIt" "GetDoc"
+                    "GetDocImprecise" "GetParent" "GetType"
+                    "GetTypeImprecise" "GoTo" "GoToDeclaration"
+                    "GoToDefinition" "GoToImprecise" "GoToInclude"))
+        (result (deferred:sync!
+                  (ycmd--get-defined-subcommands))))
+    (should (equal result commands))))
+
+(ycmd-ert-deftest get-defined-subcommands-python "test.py" 'python-mode
+  :line 1 :column 1
+  (let ((commands '("GetDoc" "GoTo" "GoToDeclaration" "GoToDefinition"
+                    "GoToReferences" "RestartServer"))
+        (result (deferred:sync!
+                  (ycmd--get-defined-subcommands))))
+    (should (equal result commands))))
+
+(ycmd-ert-deftest get-defined-subcommands-go "test.go" 'go-mode
+  :line 1 :column 1
+  (let ((commands '("GoTo" "GoToDeclaration" "GoToDefinition"
+                    "RestartServer"))
+        (result (deferred:sync!
+                  (ycmd--get-defined-subcommands))))
+    (should (equal result commands))))
+
+(ycmd-ert-deftest get-defined-subcommands-typescript "test.ts" 'typescript-mode
+  :line 1 :column 1
+  (let ((commands '("GetDoc" "GetType" "GoToDefinition" "GoToReferences"
+                    "GoToType" "RefactorRename" "RestartServer"))
+        (result (deferred:sync!
+                  (ycmd--get-defined-subcommands))))
+    (should (equal result commands))))
+
+(ycmd-ert-deftest get-defined-subcommands-javascript "simple_test.js" 'js-mode
+  :line 1 :column 1
+  (let ((commands '("GetDoc" "GetType" "GoTo" "GoToDefinition"
+                    "GoToReferences" "RefactorRename" "RestartServer"))
+        (result (deferred:sync!
+                  (ycmd--get-defined-subcommands))))
+    (should (equal result commands))))
+
 (ycmd-ert-deftest get-completions-cpp "test.cpp" 'c++-mode
   :line 8 :column 7
   (let ((response (ycmd-get-completions :sync)))
@@ -176,6 +218,18 @@ response."
           (should nil)
         (should (= .column_num 11))
         (should (= .line_num 5))))))
+
+(ycmd-ert-deftest goto-references-not-available "test-goto.cpp" 'c++-mode
+  :line 9 :column 7
+  ;; we need to temporarly overwrite `message' in order to
+  ;; check the return string
+  (cl-letf (((symbol-function 'message)
+             (lambda (format-string &rest args)
+              (apply 'format format-string args))))
+    (let ((result (deferred:sync!
+                    (ycmd--run-completer-command "GoToReferences" nil))))
+      (should (string= "GoToReferences is not supported by current completer"
+                       result)))))
 
 (ycmd-ert-deftest get-completions-python "test.py" 'python-mode
   :line 7 :column 3


### PR DESCRIPTION
Add function to retrieve supported subcommands and check when running `/run_completer_command` request. Thes subcommands are cached so it's a cheap operation to check against them.

IMHO it's more clear and comprehensive to check subcommand availability beforehand the `run_completer_command` instead of parsing the error message of a failed request. Also in the latter case we would need to forward the request to the exception to get the original subcommand of the request, which is IMHO also not very nice. 