### PR TITLE
Ycmd eldoc improvements

### DIFF
--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -757,27 +757,32 @@ response."
     (should (equal (company-ycmd--extract-meta-python data)
                    "foo(self, a, b) -> bar"))))
 
+(defun ycmd-test-eldoc-func ()
+  (deferred:sync!
+    (deferred:next
+      (lambda () (or (ycmd-eldoc--info-at-point) "")))))
+
 (ycmd-ert-deftest eldoc-info-at-point-on-keyword "test-eldoc.cpp" 'c++-mode
   :line 8 :column 8
-  (should (equal (substring-no-properties (ycmd-eldoc--info-at-point))
+  (should (equal (substring-no-properties (ycmd-test-eldoc-func))
                  "void bar( int x )")))
 (ycmd-ert-deftest eldoc-info-at-point-between-par "test-eldoc.cpp" 'c++-mode
   :line 8 :column 11
-  (should (equal (substring-no-properties (ycmd-eldoc--info-at-point))
+  (should (equal (substring-no-properties (ycmd-test-eldoc-func))
                  "void bar( int x )")))
 
 (ycmd-ert-deftest eldoc-force-semantic-info-fail "test-eldoc.cpp" 'c++-mode
   :line 8 :column 5
   (let ((ycmd-eldoc-always-semantic-server-query-modes nil)
         (ycmd-force-semantic-completion nil))
-    (should-not (ycmd-eldoc--info-at-point))))
+    (should-not (ycmd-test-eldoc-func))))
 
 (ycmd-ert-deftest eldoc-force-semantic-info "test-eldoc.cpp" 'c++-mode
   :line 8 :column 5
   (skip-unless (not (version-list-< (version-to-list emacs-version) '(24 4))))
   (let ((ycmd-eldoc-always-semantic-server-query-modes t)
         (ycmd-force-semantic-completion nil))
-    (should (equal (substring-no-properties (ycmd-eldoc--info-at-point))
+    (should (equal (substring-no-properties (ycmd-test-eldoc-func))
                    "Foo l"))))
 
 (ert-deftest ycmd-test-not-running ()

--- a/ycmd-eldoc.el
+++ b/ycmd-eldoc.el
@@ -4,7 +4,7 @@
 
 ;; Author: Peter Vasil <mail@petervasil.net>
 ;; URL: https://github.com/abingham/emacs-ycmd
-;; Version: 0.1
+;; Version: 0.2
 ;; Package-Requires: ((ycmd "0.1") (deferred "0.2.0") (s "1.9.0") (dash "2.12.1") (cl-lib "0.5") (let-alist "1.0.4"))
 
 ;; This program is free software; you can redistribute it and/or modify
@@ -127,17 +127,28 @@ foo(bar, |baz); -> foo|(bar, baz);"
 (defun ycmd-eldoc-setup ()
   "Setup eldoc for `ycmd-mode'."
   (interactive)
-  (if (eval-when-compile (fboundp 'add-function))
-      (add-function :before-until (local 'eldoc-documentation-function)
-                    #'ycmd-eldoc--documentation-function)
-    (set (make-local-variable 'eldoc-documentation-function)
-         'ycmd-eldoc--documentation-function))
-  (add-hook 'ycmd-after-teardown-hook #'ycmd-eldoc--teardown)
-  (eldoc-mode +1))
+  (ycmd-eldoc-mode +1))
+(make-obsolete 'ycmd-eldoc-setup 'ycmd-eldoc-mode "0.2")
 
 (defun ycmd-eldoc--teardown ()
   "Reset `ycmd-eldoc--cache'."
   (setq ycmd-eldoc--cache nil))
+
+;;;###autoload
+(define-minor-mode ycmd-eldoc-mode
+  "Toggle eldoc mode."
+  :lighter ""
+  (if ycmd-eldoc-mode
+      (progn
+        (set (make-local-variable 'eldoc-documentation-function)
+             'ycmd-eldoc--documentation-function)
+        (eldoc-mode +1)
+        (add-hook 'ycmd-after-teardown-hook
+                  #'ycmd-eldoc--teardown nil 'local))
+    (kill-local-variable 'eldoc-documentation-function)
+    (eldoc-mode -1)
+    (remove-hook 'ycmd-after-teardown-hook
+                 #'ycmd-eldoc--teardown 'local)))
 
 (provide 'ycmd-eldoc)
 


### PR DESCRIPTION
- Fix `ycmd-eldoc-setup` for Emacs version < 25 (Fixes #409 )
- Get eldoc message asynchronously