### PR TITLE
ycmd-eldoc: Check if semantic completer exists before sending requests

### DIFF
--- a/test/resources/test-eldoc.el
+++ b/test/resources/test-eldoc.el
@@ -1,0 +1,1 @@
+(setq test t)

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -787,6 +787,14 @@ response."
     (should (equal (substring-no-properties (ycmd-test-eldoc-func))
                    "Foo l"))))
 
+(ycmd-ert-deftest semantic-completer-available "test-eldoc.cpp" 'c++-mode
+  :line 8 :column 5
+  (should (eq (ycmd-semantic-completer-available?) t)))
+
+(ycmd-ert-deftest semantic-completer-not-available "test-eldoc.el" 'emacs-lisp-mode
+  :line 1 :column 3
+  (should (eq (ycmd-semantic-completer-available?) 'none)))
+
 (ert-deftest ycmd-test-not-running ()
   (should-not (ycmd-running?)))
 


### PR DESCRIPTION
We need to disable `ycmd-eldoc-mode` in buffers with `ycmd-mode` enabled but without semantic completer support, because we rely on semantic feature for eldoc and else we get spammed with `No semantic completer available` messages in the minibuffer.