### PR TITLE
Same response handler for FixIt and RefactorRename requests

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@
   request has not returned anything.
 * `ycmd-eldoc` gets automatically disabled if there is not semantic completer
   support for major mode. This prevents error messages in minibuffer.
+* `*ymcd-fixits` buffer can now also show responses from `RefactorRename`
+  requests
 
 # 1.1 (Mar 29, 2017)
 


### PR DESCRIPTION
Unify response handlers for `FixIt` and `RefactorRename` responses and make the same handler work for both request, because under the hood they have the same response data structure.
Make the `*ycmd-fixits*` buffer also work for `RefactoRename` requests.