### PR TITLE
Add completer function

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@
   support for major mode. This prevents error messages in minibuffer.
 * `*ymcd-fixits` buffer can now also show responses from `RefactorRename`
   requests
+* Add `ycmd-completer` command and new variable `ycmd-completing-read-function`
 
 # 1.1 (Mar 29, 2017)
 

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -139,10 +139,46 @@ response."
   "Run a request with SUBCOMMAND and eval BODY with response."
   (declare (indent 1))
   `(deferred:sync!
-     (ycmd--run-completer-command
-      ,subcommand
-      (lambda (response)
-        ,(macroexpand-all body)))))
+     (ycmd--run-completer-command ,subcommand
+       (lambda (response)
+         ,(macroexpand-all body)))))
+
+(ycmd-ert-deftest get-defined-subcommands-cpp "test.cpp" 'c++-mode
+  :line 1 :column 1
+  (let ((commands '("ClearCompilationFlagCache" "FixIt" "GetDoc"
+                    "GetDocImprecise" "GetParent" "GetType"
+                    "GetTypeImprecise" "GoTo" "GoToDeclaration"
+                    "GoToDefinition" "GoToImprecise" "GoToInclude"))
+        (result (ycmd--get-defined-subcommands)))
+    (should (equal result commands))))
+
+(ycmd-ert-deftest get-defined-subcommands-python "test.py" 'python-mode
+  :line 1 :column 1
+  (let ((commands '("GetDoc" "GoTo" "GoToDeclaration" "GoToDefinition"
+                    "GoToReferences" "RestartServer"))
+        (result (ycmd--get-defined-subcommands)))
+    (should (equal result commands))))
+
+(ycmd-ert-deftest get-defined-subcommands-go "test.go" 'go-mode
+  :line 1 :column 1
+  (let ((commands '("GoTo" "GoToDeclaration" "GoToDefinition"
+                    "RestartServer"))
+        (result (ycmd--get-defined-subcommands)))
+    (should (equal result commands))))
+
+(ycmd-ert-deftest get-defined-subcommands-typescript "test.ts" 'typescript-mode
+  :line 1 :column 1
+  (let ((commands '("GetDoc" "GetType" "GoToDefinition" "GoToReferences"
+                    "GoToType" "RefactorRename" "RestartServer"))
+        (result (ycmd--get-defined-subcommands)))
+    (should (equal result commands))))
+
+(ycmd-ert-deftest get-defined-subcommands-javascript "simple_test.js" 'js-mode
+  :line 1 :column 1
+  (let ((commands '("GetDoc" "GetType" "GoTo" "GoToDefinition"
+                    "GoToReferences" "RefactorRename" "RestartServer"))
+        (result (ycmd--get-defined-subcommands)))
+    (should (equal result commands))))
 
 (ycmd-ert-deftest get-completions-cpp "test.cpp" 'c++-mode
   :line 8 :column 7

--- a/ycmd-eldoc.el
+++ b/ycmd-eldoc.el
@@ -181,7 +181,7 @@ foo(bar, |baz); -> foo|(bar, baz);"
           (cond ((ycmd--unsupported-subcommand? response)
                  (setq ycmd-eldoc--get-type-supported-p nil))
                 ((not (ycmd--exception? response))
-                 (--when-let (ycmd--get-parent-or-type response)
+                 (--when-let (ycmd--get-message response)
                    (when (cdr it) (car it))))))))))
 
 ;;;###autoload


### PR DESCRIPTION
Add new function `ycmd-completer` which sends a `run_completer_command` requests and dispatches the reponse to handlers according their types. There is no need to specify the handler manually anymore. `ycmd-completer` can also be called interactively which prompts the user to enter a subcommand from the list of available subcommands for completer.
Also rename the handlers so that their name reflect the type of response they handle.