### PR TITLE
Add structure for request data

### DIFF
--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -79,10 +79,9 @@
     (ycmd-open)
     (ycmd-wait-until-server-is-ready)
     (ycmd-mode)
+    (ycmd-load-conf-file ycmd-test-extra-conf)
     (deferred:sync!
-      (ycmd-load-conf-file ycmd-test-extra-conf))
-    (deferred:sync!
-      (ycmd--notify-server "BufferVisit"))
+      (ycmd--event-notification "BufferVisit"))
     (deferred:sync!
       (ycmd-notify-file-ready-to-parse))))
 

--- a/ycmd-eldoc.el
+++ b/ycmd-eldoc.el
@@ -173,16 +173,15 @@ foo(bar, |baz); -> foo|(bar, baz);"
 
 (defun ycmd-eldoc--get-type ()
   "Get type at current position."
-  (let ((data (ycmd--get-request-data)))
-    (deferred:$
-      (ycmd--send-subcommand-request "GetType" data)
-      (deferred:nextc it
-        (lambda (response)
-          (cond ((ycmd--unsupported-subcommand? response)
-                 (setq ycmd-eldoc--get-type-supported-p nil))
-                ((not (ycmd--exception? response))
-                 (--when-let (ycmd--get-message response)
-                   (when (cdr it) (car it))))))))))
+  (deferred:$
+    (ycmd--command-request "GetType")
+    (deferred:nextc it
+      (lambda (response)
+        (cond ((ycmd--unsupported-subcommand? response)
+               (setq ycmd-eldoc--get-type-supported-p nil))
+              ((not (ycmd--exception? response))
+               (--when-let (ycmd--get-message response)
+                 (when (cdr it) (car it)))))))))
 
 ;;;###autoload
 (defun ycmd-eldoc-setup ()


### PR DESCRIPTION
This PR adds a `defstruct` for the `location` and `content` request data that is needed in `ycmd--request`. This encapsulates and makes the creation of the request data more descriptive 