### PR TITLE
Drop support for Emacs 24.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ addons:
 env:
   matrix:
     # Run unit tests against oldest supported stable, latest stable, and trunk
-    - EMACS_VERSION=24.3
+    - EMACS_VERSION=24.4
     - EMACS_VERSION=25.1
     - EMACS_VERSION=snapshot COMPILEFLAGS='error-on-warn'
 before_install:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@
 * `*ymcd-fixits` buffer can now also show responses from `RefactorRename`
   requests
 * Add `ycmd-completer` command and new variable `ycmd-completing-read-function`
+* Require Emacs 24.4 as minimum version
 
 # 1.1 (Mar 29, 2017)
 

--- a/ycmd.el
+++ b/ycmd.el
@@ -6,7 +6,7 @@
 ;;          Peter Vasil <mail@petervasil.net>
 ;; Version: 1.2-cvs
 ;; URL: https://github.com/abingham/emacs-ycmd
-;; Package-Requires: ((emacs "24.3") (dash "2.12.1") (s "1.10.0") (deferred "0.3.2") (cl-lib "0.5") (let-alist "1.0.4") (request "0.2.0") (request-deferred "0.2.0") (pkg-info "0.4"))
+;; Package-Requires: ((emacs "24.4") (dash "2.12.1") (s "1.10.0") (deferred "0.3.2") (cl-lib "0.5") (let-alist "1.0.4") (request "0.3.0") (request-deferred "0.2.0") (pkg-info "0.4"))
 ;;
 ;; This file is not part of GNU Emacs.
 ;;


### PR DESCRIPTION
One of our key dependecies `request`, dropped support for Emacs 24.3, so we cannot install it as a dependency on 24.3.

See: https://github.com/tkf/emacs-request/pull/70