### PR TITLE
company-ycmd: Use new format for python functions in ycmd

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -282,7 +282,7 @@ with spaces."
   "Construct completion string from a CANDIDATE for python file-types."
   (company-ycmd--with-destructured-candidate candidate
     (let* ((kind (s-replace "\n" " " .extra_menu_info))
-           (params (and (s-prefix-p "function" kind)
+           (params (and (s-prefix-p "def" kind)
                         (company-ycmd--extract-params-python
                          .detailed_info .insertion_text)))
            (meta (company-ycmd--extract-meta-python .detailed_info))

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -562,7 +562,7 @@ response."
                      (line_num . 6)
                      (column_num . 7)
                      (filepath . "/foo/bar.py")))
-                   (extra_menu_info . "function: bar.Foo.foo")))
+                   (extra_menu_info . "def bar.Foo.foo")))
            (candidate (company-ycmd--construct-candidate-python data)))
       (let-alist data
         (should (string= .insertion_text (substring-no-properties candidate)))


### PR DESCRIPTION
ycmd now indicates a python function in extra_menu_info with `def` instead of
`function`.

See:
https://github.com/Valloric/ycmd/commit/72bfc38f245df319c8dff0965dd86d950b631947