### PR TITLE
ycmd-eldoc: Use GetTypeImprecise if applicable

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,8 @@
   requests
 * Add `ycmd-completer` command and new variable `ycmd-completing-read-function`
 * Require Emacs 24.4 as minimum version
+* Use `GetTypeImprecise` as fallback in `ycmd-eldoc` instead of `GetType` if
+  supported by filetype completer
 
 # 1.1 (Mar 29, 2017)
 


### PR DESCRIPTION
This is a small optimization for `ycmd-eldoc`. 

`GetTypeImprecise`  does not reparse the buffer like `GetType` and since we parsing the buffer on many other events,  I guess it is totally fiine to use this. Ask the server first it the subcommand is supported.

I think this should also go into emacs-ycmd 1.2