### PR TITLE
Add ycmd-with-handled-server-exceptions macro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: emacs-lisp
 sudo: false
 cache:
   directories:
-    - .cask/
+    # - .cask/
     - $HOME/emacs
     - $HOME/.ccache
     - $HOME/ycmd
@@ -31,7 +31,7 @@ env:
     - EMACS_VERSION=snapshot COMPILEFLAGS='error-on-warn'
 before_install:
   # gcc-4.9
-  - mkdir "${HOME}/bin"
+  - mkdir -p "${HOME}/bin"
   - ln -s "/usr/bin/g++-4.9" "${HOME}/bin/c++"
   - ln -s "/usr/bin/gcc-4.9" "${HOME}/bin/cc"
   - ln -s "/usr/bin/gcov-4.9" "${HOME}/bin/gcov"
@@ -46,6 +46,7 @@ before_install:
   - travis/install_ycmd.sh
 
 install:
+  - echo $PATH
   - if [[ -n $EMACS_VERSION ]]; then make deps; fi
 script:
   - if [[ -n $EMACS_VERSION ]]; then make all; fi

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,10 @@ CONVERT = convert
 VERSION := $(shell EMACS=$(EMACS) $(CASK) version)
 PKGDIR := $(shell EMACS=$(EMACS) $(CASK) package-directory)
 
-# Export the used EMACS to recipe environments
+# Export Emacs to goals, mainly for CASK
+CASK_EMACS = $(EMACS)
 export EMACS
+export CASK_EMACS
 
 SRCS = ycmd.el contrib/ycmd-next-error.el
 

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -249,13 +249,14 @@ response."
   :line 9 :column 7
   ;; we need to temporarly overwrite `message' in order to
   ;; check the return string
-  (cl-letf (((symbol-function 'message)
-             (lambda (format-string &rest args)
-              (apply 'format format-string args))))
-    (let ((result (ycmd-deferred:sync!
-                    (ycmd--run-completer-command "GoToReferences" nil))))
-      (should (string= "GoToReferences is not supported by current Completer"
-                       result)))))
+  (let (result)
+    (cl-letf (((symbol-function 'message)
+               (lambda (format-string &rest args)
+                 (setq result (apply 'format format-string args)))))
+      (let ((ycmd-after-exception-hook nil))
+        (ycmd-deferred:sync!
+         (ycmd--run-completer-command "GoToReferences" nil))
+        (should (string-prefix-p "ValueError: Supported commands are:" result))))))
 
 (ycmd-ert-deftest get-completions-python "test.py" 'python-mode
   :line 7 :column 3


### PR DESCRIPTION
I have this branch for a couple of months and was using it at work without problems.

This PR introduces a new macro `ycmd-with-handled-server-exceptions` which wraps all boiler-plate code for handling exceptions and running code on exception or if we should bind the `current-buffer` for the request and response when we need to make sure we run the response code in the buffer that was used for the request.

@abingham What do you think?