### PR TITLE
Fix path on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
-language: emacs-lisp
+language: python
 sudo: false
 cache:
   directories:
-    # - .cask/
+    - .cask/
     - $HOME/emacs
     - $HOME/.ccache
     - $HOME/ycmd
@@ -46,7 +46,6 @@ before_install:
   - travis/install_ycmd.sh
 
 install:
-  - echo $PATH
   - if [[ -n $EMACS_VERSION ]]; then make deps; fi
 script:
   - if [[ -n $EMACS_VERSION ]]; then make all; fi

--- a/travis/install_ycmd.sh
+++ b/travis/install_ycmd.sh
@@ -14,6 +14,12 @@ git submodule update --init --recursive
 export EXTRA_CMAKE_ARGS="-DCMAKE_CXX_COMPILER=/usr/lib/ccache/c++ -DCMAKE_C_COMPILER=/usr/lib/ccache/cc"
 python build.py --clang-completer --gocode-completer --tern-completer
 
+valNumResult=$?
+if [[ $valNumResult -eq 1 ]]
+then
+  return 1
+fi
+
 npm install -g typescript
 
 popd


### PR DESCRIPTION
Due to pyenv putting `/usr/bin` in front of the path in  python environment (cask is using python and the ycmd installer too) (See [here](https://github.com/travis-ci/travis-ci/issues/8486) and [here](https://github.com/pyenv/pyenv/issues/789)) This breaks the usage of `$HOME/bin` which is the place where we install gcc4.9 and our requested Emacs version.

Setting travis language to `python` fixes the issue because virtualenv is used instead of pyenv  