### PR TITLE
Use `p` as suffix for predicate functions

### DIFF
--- a/company-ycmd.el
+++ b/company-ycmd.el
@@ -496,7 +496,7 @@ If CB is non-nil, call it with candidates."
   "Prefix-command handler for the company backend."
   (and ycmd-mode
        buffer-file-name
-       (ycmd-running?)
+       (ycmd-running-p)
        (or (not (company-in-string-or-comment))
            (company-ycmd--in-include))
        (or (company-grab-symbol-cons "\\.\\|->\\|::\\|/" 2)

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -836,14 +836,14 @@ response."
 
 (ycmd-ert-deftest semantic-completer-available "test-eldoc.cpp" 'c++-mode
   :line 8 :column 5
-  (should (eq (ycmd-semantic-completer-available?) t)))
+  (should (eq (ycmd-semantic-completer-available-p) t)))
 
 (ycmd-ert-deftest semantic-completer-not-available "test-eldoc.el" 'emacs-lisp-mode
   :line 1 :column 3
-  (should (eq (ycmd-semantic-completer-available?) 'none)))
+  (should (eq (ycmd-semantic-completer-available-p) 'none)))
 
 (ert-deftest ycmd-test-not-running ()
-  (should-not (ycmd-running?)))
+  (should-not (ycmd-running-p)))
 
 (ert-deftest ycmd-test-json-encode ()
   (let ((data '((foo))))
@@ -852,8 +852,8 @@ response."
 
 (ert-deftest ycmd-test-location-data-predicate ()
   (let ((data '((filepath . ,file-path) (column_num . 34) (line_num . 15))))
-    (should (ycmd--location-data? data))
-    (should-not (ycmd--location-data? (list data)))))
+    (should (ycmd--location-data-p data))
+    (should-not (ycmd--location-data-p (list data)))))
 
 (ert-deftest ycmd-test-filter-and-sort-candidates1 ()
   (skip-unless (not (version-list-< (version-to-list emacs-version) '(24 4))))

--- a/ycmd-eldoc.el
+++ b/ycmd-eldoc.el
@@ -78,7 +78,7 @@ is only semantic after a semantic trigger."
   (deferred:$
     (deferred:next
       (lambda ()
-        (ycmd-semantic-completer-available?)))
+        (ycmd-semantic-completer-available-p)))
     (deferred:nextc it
       (lambda (response)
         (when (and response (eq response 'none))


### PR DESCRIPTION
Let's use `p` instead of `?` as suffix for predicate functions since it is suggested in the emacs coding conventions (See Info Node `(elisp) Coding Conventions`)

Some of the predicate functions are already using `p`. 