### PR TITLE
Modify "Unbuffered output ..." section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ that:
 After this you can use your standard `company-mode` keybindings to do
 completion.
 
-## IMPORTANT: Unbuffered output on Windows
+## IMPORTANT: Unbuffered output
 
-There have been some reports that `ycmd.el` doesn't work on Windows when Python's output is buffered. See, for example, [issue #104](https://github.com/abingham/emacs-ycmd/issues/104). This is because we rely on the ycmd server printing out its host and port information in a timely (i.e. unbuffered) manner. We will almost certainly update the defaults for `ycmd.el` to force unbuffered output.
+There have been some reports that `ycmd.el` doesn't work when Python's output is buffered. See, for example, [issue #104](https://github.com/abingham/emacs-ycmd/issues/104). This is because we rely on the ycmd server printing out its host and port information in a timely (i.e. unbuffered) manner. We will almost certainly update the defaults for `ycmd.el` to force unbuffered output.
 
-In any event, if you are facing problems with ycmd not starting and/or hanging Emacs on Windows, try adding `-u` to your `ycmd-server-command`. For example:
+In any event, if you are facing problems with ycmd not starting and/or hanging Emacs, try adding `-u` to your `ycmd-server-command`. For example:
 ```
 (set-variable 'ycmd-server-command '("c:/path/to/python.exe" "-u" "c:/path/to/ycmd"))
 ```


### PR DESCRIPTION
I experienced the issue #429 on my Arch Linux machine. Since the [readme](https://github.com/abingham/emacs-ycmd#important-unbuffered-output) mentioned this was a Windows issue, I foolishly disregarded this as a fix. After spending sometime trying to resolve the issue, I decided to add `-u` to my `ycmd-server-command`, lo and behold it worked.
I just want to make sure no one else makes the same stupid mistake I made.