### PR TITLE
Fix level assignment for unknown kinds.

### DIFF
--- a/flycheck-ycmd.el
+++ b/flycheck-ycmd.el
@@ -73,7 +73,7 @@
        :filename .location.filepath
        :message (concat .text (when (eq .fixit_available t) " (FixIt available)"))
        :checker checker
-       :level (assoc-default .kind flycheck-ycmd--level-map 'string-equal 'error)))))
+       :level (or (cdr (assoc-string .kind flycheck-ycmd--level-map)) 'error)))))
 
 (defun flycheck-ycmd--start (checker callback)
   "Start ycmd flycheck CHECKER using CALLBACK to communicate with flycheck."


### PR DESCRIPTION
Despite its name, ‘assoc-default’ doesn’t return the default argument if the
key isn’t found.