### PR TITLE
Integrate YCMD JSON settings

### DIFF
--- a/test/run.el
+++ b/test/run.el
@@ -59,6 +59,7 @@
                           ycmd-path-raw
                         (expand-file-name ycmd-path-raw source-directory)))
            (ycmd-server-command (list python-path ycmd-path))
+           (ycmd-settings-json-filepath (concat ycmd-path "/default_settings.json"))
            (ert-selector (pop argv))
            (ycmd-request-backend (intern (pop argv)))
            (request-backend (if (memq ycmd-request-backend '(curl url-retrieve))

--- a/test/run.el
+++ b/test/run.el
@@ -59,7 +59,6 @@
                           ycmd-path-raw
                         (expand-file-name ycmd-path-raw source-directory)))
            (ycmd-server-command (list python-path ycmd-path))
-           (ycmd-settings-json-filepath (concat ycmd-path "/default_settings.json"))
            (ert-selector (pop argv))
            (ycmd-request-backend (intern (pop argv)))
            (request-backend (if (memq ycmd-request-backend '(curl url-retrieve))

--- a/test/ycmd-test.el
+++ b/test/ycmd-test.el
@@ -196,7 +196,14 @@ response."
       (should (= .completion_start_column 7)))))
 
 (ert-deftest ycmd-test-no-semantic-completion-cpp ()
-  (let ((ycmd-auto-trigger-semantic-completion))
+  (let* ((settings-file (make-temp-file "ycmd-options"))
+         (original-file  ycmd-settings-json-filepath)
+         (ycmd-settings-json-filepath settings-file)
+         (json (json-read-file original-file)))
+    (assq-delete-all 'auto_trigger json)
+    (setq json (json-add-to-object json "auto_trigger" 0))
+    (with-temp-file settings-file
+      (insert (ycmd--json-encode json)))
     (ycmd-ert-with-resource-buffer "test.cpp" 'c++-mode
       (let ((current-position
              (ycmd--col-line-to-position

--- a/ycmd.el
+++ b/ycmd.el
@@ -2225,7 +2225,7 @@ The timeout can be set with the variable
 (eval-and-compile
   (if (version-list-< (version-to-list emacs-version) '(25))
       (defun ycmd--encode-string (s) s)
-    (defun ycmd--encode-string (s) (encode-coding-string s 'utf-8 t))))
+    (defun ycmd--encode-string (s) (encode-coding-string s 'utf-8))))
 
 (defun ycmd--get-basic-request-data ()
   "Build the basic request data alist for a server request."

--- a/ycmd.el
+++ b/ycmd.el
@@ -107,6 +107,7 @@
   (require 'cl-lib)
   (require 'let-alist))
 (require 'dash)
+(require 'f)
 (require 's)
 (require 'deferred)
 (require 'hmac-def)
@@ -130,7 +131,7 @@
   "Path to global extra conf file."
   :type '(string))
 
-(defcustom ycmd-settings-json-filepath (concat (file-name-directory load-file-name) "ycmd_default_settings.json")
+(defcustom ycmd-settings-json-filepath (f-join (f-dirname (f-this-file)) "ycmd_default_settings.json")
   "Path to YCMD settings JSON file."
   :type '(string))
 

--- a/ycmd.el
+++ b/ycmd.el
@@ -130,7 +130,7 @@
   "Path to global extra conf file."
   :type '(string))
 
-(defcustom ycmd-settings-json-filepath nil
+(defcustom ycmd-settings-json-filepath (concat (file-name-directory load-file-name) "ycmd_default_settings.json")
   "Path to YCMD settings JSON file."
   :type '(string))
 

--- a/ycmd_default_settings.json
+++ b/ycmd_default_settings.json
@@ -1,0 +1,54 @@
+{
+  "filepath_completion_use_working_dir": 0,
+  "auto_trigger": 1,
+  "min_num_of_chars_for_completion": 2,
+  "min_num_identifier_candidate_chars": 0,
+  "semantic_triggers": {},
+  "filetype_specific_completion_to_disable": {
+    "gitcommit": 1
+  },
+  "seed_identifiers_with_syntax": 0,
+  "collect_identifiers_from_comments_and_strings": 0,
+  "collect_identifiers_from_tags_files": 0,
+  "max_num_identifier_candidates": 10,
+  "max_num_candidates": 50,
+  "extra_conf_globlist": [],
+  "global_ycm_extra_conf": "",
+  "confirm_extra_conf": 1,
+  "complete_in_comments": 0,
+  "complete_in_strings": 1,
+  "max_diagnostics_to_display": 30,
+  "filetype_whitelist": {
+    "*": 1
+  },
+  "filetype_blacklist": {
+    "tagbar": 1,
+    "qf": 1,
+    "notes": 1,
+    "markdown": 1,
+    "netrw": 1,
+    "unite": 1,
+    "text": 1,
+    "vimwiki": 1,
+    "pandoc": 1,
+    "infolog": 1,
+    "mail": 1
+  },
+  "filepath_blacklist": {
+    "html": 1,
+    "jsx": 1,
+    "xml": 1
+  },
+  "auto_start_csharp_server": 1,
+  "auto_stop_csharp_server": 1,
+  "use_ultisnips_completer": 1,
+  "csharp_server_port": 0,
+  "hmac_secret": "",
+  "server_keep_logfiles": 0,
+  "gocode_binary_path": "",
+  "godef_binary_path": "",
+  "rust_src_path": "",
+  "racerd_binary_path": "",
+  "python_binary_path": "",
+  "java_jdtls_use_clean_workspace": 1
+}


### PR DESCRIPTION
Add `ycmd-settings-json-filepath` - path to YCMD settings JSON file.
YCMD accepts a json file where the server settings are set, including
a one-time HMAC. The file is deleted after the server starts.
As for now, emacs-ycmd was just creating a temporary file from
some hard-coded/customizable values.
Since those settings have to direct relation to emacs-ycmd, rather
only to YCMD, it is good idea to keep it this way and just feed the
file adding an HMAC value.

That change will read the JSON file, insert HMAC and pass it to YCMD.
Please, test it, feedback is appreciated, I will mainly test it on
C/C++ and Go.

That is supposed to solve #472, #479.

I copied `ycmd/default_settings.json` to my .emacs. and use it 

    ycmd-settings-json-filepath (concat user-emacs-directory "ycmd_default_setting.json")
