### PR TITLE
Add java-mode into ycmd-file-type-map.

### DIFF
--- a/ycmd.el
+++ b/ycmd.el
@@ -298,6 +298,7 @@ list
     (erlang-mode . ("erlang"))
     (emacs-lisp-mode . ("elisp"))
     (go-mode . ("go"))
+    (java-mode . ("java"))
     (js-mode . ("javascript"))
     (js2-mode . ("javascript"))
     (lua-mode . ("lua"))


### PR DESCRIPTION
Fix the error message: "ycmd.responses.ServerError: Request missing required field"
Tested on Spacemacs.